### PR TITLE
HTML pretty format broken in Rails >= 3.0.8 and 3.1.0.rc2 

### DIFF
--- a/lib/temple/html/pretty.rb
+++ b/lib/temple/html/pretty.rb
@@ -35,7 +35,7 @@ module Temple
           tmp = unique_name
           [:multi,
            [:code, "#{tmp} = (#{code}).to_s"],
-           [:code, "#{tmp} = #{tmp}.gsub(\"\\n\", #{indent.inspect}) if #{@pre_tags_name} !~ #{tmp}"],
+           [:code, "#{tmp}.to_str.gsub!(\"\\n\", #{indent.inspect}) if #{@pre_tags_name} !~ #{tmp}"],
            [:dynamic, tmp]]
         else
           [:dynamic, code]

--- a/test/html/test_pretty.rb
+++ b/test/html/test_pretty.rb
@@ -22,7 +22,7 @@ describe Temple::HTML::Pretty do
                         [:static, "text"],
                         [:multi,
                          [:code, "_temple_html_pretty2 = (code).to_s"],
-                         [:code, '_temple_html_pretty2 = _temple_html_pretty2.gsub("\n", "\n    ") if _temple_html_pretty1 !~ _temple_html_pretty2'],
+                         [:code, '_temple_html_pretty2.to_str.gsub!("\n", "\n    ") if _temple_html_pretty1 !~ _temple_html_pretty2'],
                          [:dynamic, "_temple_html_pretty2"]]],
                        [:static, "</p>"]],
                       [:static, "\n</div>"]]]


### PR DESCRIPTION
From Rails 3.0.8 and 3.1.0.rc2 onwards, `gsub` is no longer considered safe either. We need to `to_str` first then `gsub!` it.
