### PR TITLE
Keep HTML attributes in their original order

### DIFF
--- a/lib/temple/html/attribute_merger.rb
+++ b/lib/temple/html/attribute_merger.rb
@@ -38,7 +38,7 @@ module Temple
             result[name] = attr
           end
         end
-        [:multi, *result.sort.map {|name,attr| compile(attr) }]
+        [:multi, *result.map {|name,attr| compile(attr) }]
       end
 
       def on_html_attr(name, value)


### PR DESCRIPTION
By the HTML spec, element attributes may appear in any order, but for some reason not apparent in its version history, Temple imposes the alphabetical ordering to them. I think it's pointless, makes comparing the abstract source vs. rendered output harder, and should thus be removed. (And, FWIW, this probably brings a negligible improvement to rendering times.)

For an example, in Slim notation,

```
meta(http-equiv="Content-Type" content="text/html; charset=utf-8")
```

renders nicer when the output is unsorted like:

```
<meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
```

rather than sorted like:

```
<meta content="text/html; charset=utf-8" http-equiv="Content-Type" />
```
