### PR TITLE
Separate attribute sorting and merging responsibilities

### DIFF
--- a/lib/temple.rb
+++ b/lib/temple.rb
@@ -45,5 +45,6 @@ module Temple
     autoload :Fast,               'temple/html/fast'
     autoload :Pretty,             'temple/html/pretty'
     autoload :AttributeMerger,    'temple/html/attribute_merger'
+    autoload :AttributeSorter,    'temple/html/attribute_sorter'
   end
 end

--- a/lib/temple/html/attribute_merger.rb
+++ b/lib/temple/html/attribute_merger.rb
@@ -1,11 +1,16 @@
 module Temple
   module HTML
     # @api public
-    class AttributeMerger < Filter
+    # --
+    # TODO: Inherit from Filter instead; to sort attributes Temple users
+    # should explicitly use AttributeSorter in the filter chain instead.
+    # Since this breaks backward compatibility, it must wait until the
+    # next major version.
+    class AttributeMerger < AttributeSorter
       default_options[:attr_delimiter] = {'id' => '_', 'class' => ' '}
-      default_options[:sort_attrs] = true
 
       def on_html_attrs(*attrs)
+        attrs = super[2..-1]
         names = []
         result = {}
         attrs.each do |attr|
@@ -41,8 +46,7 @@ module Temple
             names << name
           end
         end
-        result = options[:sort_attrs] ? result.sort : names.map {|k| [k, result[k]] }
-        [:multi, *result.map {|name,attr| compile(attr) }]
+        [:multi, *names.map {|name| compile(result[name]) }]
       end
 
       def on_html_attr(name, value)

--- a/lib/temple/html/attribute_sorter.rb
+++ b/lib/temple/html/attribute_sorter.rb
@@ -1,0 +1,19 @@
+module Temple
+  module HTML
+    # @api public
+    class AttributeSorter < Filter
+      default_options[:sort_attrs] = true
+
+      def on_html_attrs(*attrs)
+        if options[:sort_attrs]
+          attrs.sort_by! do |attr|
+            raise(InvalidExpression, 'Attribute is not a html attr') if attr[0] != :html || attr[1] != :attr
+            attr[2].to_s
+          end
+        end
+
+        [:html, :attrs, *attrs]
+      end
+    end
+  end
+end

--- a/test/html/test_attribute_sorter.rb
+++ b/test/html/test_attribute_sorter.rb
@@ -1,0 +1,48 @@
+require 'helper'
+
+describe Temple::HTML::AttributeSorter do
+  before do
+    @ordered   = Temple::HTML::AttributeSorter.new
+    @unordered = Temple::HTML::AttributeSorter.new :sort_attrs => false
+  end
+
+  it 'should sort html attributes by name by default, when :sort_attrs is true' do
+    @ordered.call([:html, :tag,
+      'meta',
+      [:html, :attrs, [:html, :attr, 'c', [:static, '1']],
+                      [:html, :attr, 'd', [:static, '2']],
+                      [:html, :attr, 'a', [:static, '3']],
+                      [:html, :attr, 'b', [:static, '4']]]
+    ]).should.equal [:html, :tag, 'meta',
+                     [:html, :attrs,
+                      [:html, :attr, 'a', [:static, '3']],
+                      [:html, :attr, 'b', [:static, '4']],
+                      [:html, :attr, 'c', [:static, '1']],
+                      [:html, :attr, 'd', [:static, '2']]]]
+  end
+
+  it 'should preserve the order of html attributes when :sort_attrs is false' do
+    @unordered.call([:html, :tag,
+      'meta',
+      [:html, :attrs, [:html, :attr, 'c', [:static, '1']],
+                      [:html, :attr, 'd', [:static, '2']],
+                      [:html, :attr, 'a', [:static, '3']],
+                      [:html, :attr, 'b', [:static, '4']]]
+    ]).should.equal [:html, :tag, 'meta',
+                     [:html, :attrs,
+                      [:html, :attr, 'c', [:static, '1']],
+                      [:html, :attr, 'd', [:static, '2']],
+                      [:html, :attr, 'a', [:static, '3']],
+                      [:html, :attr, 'b', [:static, '4']]]]
+
+    # Use case:
+    @unordered.call([:html, :tag,
+      'meta',
+      [:html, :attrs, [:html, :attr, 'http-equiv', [:static, 'Content-Type']],
+                      [:html, :attr, 'content', [:static, '']]]
+    ]).should.equal [:html, :tag, 'meta',
+                     [:html, :attrs,
+                      [:html, :attr, 'http-equiv', [:static, 'Content-Type']],
+                      [:html, :attr, 'content', [:static, '']]]]
+  end
+end


### PR DESCRIPTION
Just as one might want to merge attributes but not sort them (see
b45c61), one might want to sort attributes but not merge them.
They are separate concerns, and therefore should be separate filters.
This change permits the use of AttributeSorter independently from
AttributeMerger.

Backward compatibility requires preserving the existing sorting
behavior of AttributeMerger, but in a future release it should be
fully separated, and users should explicitly use AttributeSorter
in the filter chain if they desire.
