### PR TITLE
Added html js abstraction for wrapping Javascript in HTML or CDATA comments

### DIFF
--- a/lib/temple/grammar.rb
+++ b/lib/temple/grammar.rb
@@ -30,11 +30,11 @@ module Temple
       [:html, :doctype, String]                |
       [:html, :comment, Expression]            |
       [:html, :condcomment, String, Expression]|
-      [:html, :js, CommentStyle, Expression]         |
+      [:html, :js, Expression, 'CommentStyle?']|
       [:html, :tag, HTMLIdentifier, Expression, 'Expression?'] |
       [:html, :attrs, 'HTMLAttr*']             |
       HTMLAttr
-      
+
     CommentStyle <<
       Symbol | nil
 

--- a/lib/temple/html/dispatcher.rb
+++ b/lib/temple/html/dispatcher.rb
@@ -18,8 +18,8 @@ module Temple
         [:html, :condcomment, condition, compile(content)]
       end
 
-      def on_html_js(comment, content)
-        [:html, :js, comment, compile(content)]
+      def on_html_js(content, comment = nil)
+        [:html, :js, compile(content), comment]
       end
 
       def on_html_tag(name, attrs, content = nil)

--- a/lib/temple/html/fast.rb
+++ b/lib/temple/html/fast.rb
@@ -101,7 +101,7 @@ module Temple
          [:static, options[:attr_quote]]]
       end
       
-      def on_html_js(comment,content)
+      def on_html_js(content, comment = nil)
         comment ||= options[:js_comment] || ( xhtml? ? :cdata : :html )
         comments = JS_COMMENTS[comment] or fail(FilterError, "Invalid Javascript comment #{comment}")
         [:multi,

--- a/test/html/test_fast.rb
+++ b/test/html/test_fast.rb
@@ -21,15 +21,15 @@ describe Temple::HTML::Fast do
   end
 
   it 'should compile js wrapped in comments' do
-    @html.call([:html, :js, :none, [:static, 'test']]).should.equal [:multi, [:static, ""], [:static, "test"], [:static, ""]]
-    @html.call([:html, :js, :html, [:static, 'test']]).should.equal [:multi, [:static, "<!--\n"], [:static, "test"], [:static, "\n//-->"]]
-    @html.call([:html, :js, :cdata, [:static, 'test']]).should.equal [:multi, [:static, "\n//<![CDATA[\n"], [:static, "test"], [:static, "\n//]]>\n"]]
-    @html.call([:html, :js, :both, [:static, 'test']]).should.equal [:multi, [:static, "<!--\n//<![CDATA[\n"], [:static, "test"], [:static, "\n//]]>\n//-->"]]
+    @html.call([:html, :js, [:static, 'test'], :none]).should.equal [:multi, [:static, ""], [:static, "test"], [:static, ""]]
+    @html.call([:html, :js, [:static, 'test'], :html]).should.equal [:multi, [:static, "<!--\n"], [:static, "test"], [:static, "\n//-->"]]
+    @html.call([:html, :js, [:static, 'test'], :cdata]).should.equal [:multi, [:static, "\n//<![CDATA[\n"], [:static, "test"], [:static, "\n//]]>\n"]]
+    @html.call([:html, :js, [:static, 'test'], :both]).should.equal [:multi, [:static, "<!--\n//<![CDATA[\n"], [:static, "test"], [:static, "\n//]]>\n//-->"]]
   end
 
   it 'should guess default js comment' do
-    Temple::HTML::Fast.new(:format=>:xhtml).call([:html, :js, nil, [:static, 'test']]).should.equal [:multi, [:static, "\n//<![CDATA[\n"], [:static, "test"], [:static, "\n//]]>\n"]]
-    Temple::HTML::Fast.new(:format=>:html).call([:html, :js, nil, [:static, 'test']]).should.equal [:multi, [:static, "<!--\n"], [:static, "test"], [:static, "\n//-->"]]
+    Temple::HTML::Fast.new(:format=>:xhtml).call([:html, :js, [:static, 'test']]).should.equal [:multi, [:static, "\n//<![CDATA[\n"], [:static, "test"], [:static, "\n//]]>\n"]]
+    Temple::HTML::Fast.new(:format=>:html).call([:html, :js, [:static, 'test']]).should.equal [:multi, [:static, "<!--\n"], [:static, "test"], [:static, "\n//-->"]]
   end
   
   it 'should compile autoclosed html tag' do


### PR DESCRIPTION
This is the implementation of the html abstraction for easy wrapping of javascript blocks in HTML and/or CDATA comments. See https://github.com/slim-template/slim/issues/339 and https://github.com/slim-template/slim/pull/340 for more details.
