### PR TITLE
fixing html_safe + pretty + dynamic

### DIFF
--- a/lib/temple/html/pretty.rb
+++ b/lib/temple/html/pretty.rb
@@ -40,7 +40,12 @@ module Temple
           indent_code = ''
           indent_code << "#{tmp} = #{tmp}.sub(/\\A\\s*\\n?/, \"\\n\"); " if options[:indent_tags].include?(@last)
           indent_code << "#{tmp} = #{tmp}.gsub(\"\n\", #{indent.inspect}); "
-          indent_code = "if #{tmp}.html_safe?; #{indent_code}#{tmp} = #{tmp.html_safe} end; "  if ''.respond_to?(:html_safe?)
+          if ''.respond_to?(:html_safe)
+            tmp_safe = unique_name
+            # we have to first save if the string was html_safe
+            # otherwise the gsub operation will lose that knowledge
+            indent_code = "#{tmp_safe} = #{tmp}.html_safe?; #{indent_code}#{tmp} = #{tmp}.html_safe if #{tmp_safe}; "
+          end
           @last = :dynamic
           [:multi,
            [:code, "#{tmp} = (#{code}).to_s"],

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -4,9 +4,11 @@ require 'temple'
 module TestHelper
   def with_html_safe(flag)
     String.send(:define_method, :html_safe?) { flag }
+    String.send(:define_method, :html_safe) { self }
     yield
   ensure
     String.send(:undef_method, :html_safe?) if String.method_defined?(:html_safe?)
+    String.send(:undef_method, :html_safe) if String.method_defined?(:html_safe)
   end
 
   def grammar_validate(grammar, exp, message)

--- a/test/html/test_pretty.rb
+++ b/test/html/test_pretty.rb
@@ -45,4 +45,17 @@ describe Temple::HTML::Pretty do
                        [:static, "</p>"]],
                       [:static, "</pre>"]]]
   end
+
+  it 'should not escape html_safe strings' do
+    with_html_safe(true) do
+      @html.call(
+        [:dynamic, '"text<".html_safe']
+      ).should.equal [:multi,
+                      [:code, "_temple_html_pretty1 = /<code|<pre|<textarea/"],
+                      [:multi,
+                       [:code, "_temple_html_pretty2 = (\"text<\".html_safe).to_s"],
+                       [:code, "if _temple_html_pretty1 !~ _temple_html_pretty2; _temple_html_pretty3 = _temple_html_pretty2.html_safe?; _temple_html_pretty2 = _temple_html_pretty2.gsub(\"\n\", \"\\n\"); _temple_html_pretty2 = _temple_html_pretty2.html_safe if _temple_html_pretty3; end"],
+                       [:dynamic, "_temple_html_pretty2"]]]
+    end
+  end
 end


### PR DESCRIPTION
The combination of pretty + dynamic + html_safe ends up escaping html_safe output.

Test app can be found here:
https://github.com/djsell/pretty_slim

Uncomment the last line in Gemfile and run bundle install to see the difference
