### PR TITLE
use ActionPack::VERSION instead of Rails::VERSION

### DIFF
--- a/lib/temple/templates/rails.rb
+++ b/lib/temple/templates/rails.rb
@@ -2,13 +2,13 @@ unless defined?(ActionView)
   raise "Rails is not loaded - Temple::Templates::Rails cannot be used"
 end
 
-if ::Rails::VERSION::MAJOR < 3
-  raise "Temple supports only Rails 3.x and greater, your Rails version is #{::Rails::VERSION::STRING}"
+if ::ActionPack::VERSION::MAJOR < 3
+  raise "Temple supports only Rails 3.x and greater, your Rails version is #{::ActionPack::VERSION::STRING}"
 end
 
 module Temple
   module Templates
-    if ::Rails::VERSION::MAJOR == 3 && ::Rails::VERSION::MINOR < 1
+    if ::ActionPack::VERSION::MAJOR == 3 && ::ActionPack::VERSION::MINOR < 1
       class Rails < ActionView::TemplateHandler
         include ActionView::TemplateHandlers::Compilable
         extend Mixins::Template


### PR DESCRIPTION
When I try to create a HTML mail with ActionMailer and Slim (non-Rails app), it doesn't work.
So I suggest to use `ActionPack::VERSION`.
