### PR TITLE
Reduce memory allocations in Temple::ImmutableHash

### DIFF
--- a/lib/temple/hash.rb
+++ b/lib/temple/hash.rb
@@ -22,7 +22,7 @@ module Temple
     end
 
     def keys
-      @hash.inject([]) {|keys, h| keys += h.keys }.uniq
+      @hash.inject([]) {|keys, h| keys.concat(h.keys) }.uniq
     end
 
     def values


### PR DESCRIPTION
In a very simple Sinatra app, using a simple slim template, `lib/temple/hash.rb:25` is the single line with the most memory allocations per request.

This change replaces `+=` with `#concat`, to reduce the number of new Arrays. This is safe to do within the context of `#inject`. The tests pass.

Here's an example app:

``` ruby
require "sinatra"
require "slim"

class SinatraTemplatesApp < Sinatra::Base
  HELLOS = ["Hello", "Hola", "Bonjour", "Gutentag"]
  enable :inline_templates

  get "/slim" do
    slim :slim
  end
end


run SinatraTemplatesApp.new

__END__

@@ slim
html
  body
    ul id="hi"
      - HELLOS.each do |hello|
        li.greeting
          = hello
          |  World!
```

PS: The following lines are also kind of heavy-hitters (much less than the attached fix), but I don't think there is anything to be done about them:
- `lib/temple/mixins/dispatcher.rb:6` allocates many Arrays
- `lib/temple/html/dispatcher.rb:6` allocates "many" Arrays
- `lib/temple/mixins/options.rb:81` allocates "many" Hashes
- `lib/temple/html/dispatcher.rb:26` allocates "many" Arrays
