### PR TITLE
Make Temple::Utils.escape_html_safe universal

### DIFF
--- a/lib/temple/erb/engine.rb
+++ b/lib/temple/erb/engine.rb
@@ -6,7 +6,7 @@ module Temple
     class Engine < Temple::Engine
       use Temple::ERB::Parser
       use Temple::ERB::Trimming, :trim_mode
-      filter :Escapable, :use_html_safe, :disable_escape
+      filter :Escapable, :disable_escape
       filter :MultiFlattener
       filter :DynamicInliner
       generator :ArrayBuffer

--- a/lib/temple/filters/escapable.rb
+++ b/lib/temple/filters/escapable.rb
@@ -7,15 +7,13 @@ module Temple
     #
     # @api public
     class Escapable < Filter
-      # Activate the usage of html_safe? if it is available (for Rails 3 for example)
       define_options :escape_code,
-                     :use_html_safe => ''.respond_to?(:html_safe?),
                      :disable_escape => false
+      define_deprecated_options :use_html_safe
 
       def initialize(opts = {})
         super
-        @escape_code = options[:escape_code] ||
-          "::Temple::Utils.escape_html#{options[:use_html_safe] ? '_safe' : ''}((%s))"
+        @escape_code = options[:escape_code] || "::Temple::Utils.escape_html_safe((%s))"
         @escaper = eval("proc {|v| #{@escape_code % 'v'} }")
         @escape = false
       end

--- a/lib/temple/utils.rb
+++ b/lib/temple/utils.rb
@@ -9,16 +9,6 @@ module Temple
   module Utils
     extend self
 
-    # Returns an escaped copy of `html`.
-    # Strings which are declared as html_safe are not escaped.
-    #
-    # @param html [String] The string to escape
-    # @param safe [Boolean] If false use escape_html
-    # @return [String] The escaped string
-    def escape_html_safe(html, safe = true)
-      safe && html.html_safe? ? html : escape_html(html)
-    end
-
     if defined?(EscapeUtils)
       # Returns an escaped copy of `html`.
       #
@@ -63,6 +53,31 @@ module Temple
           html.to_s.gsub(ESCAPE_HTML_PATTERN) {|c| ESCAPE_HTML[c] }
         end
       end
+    end
+
+    # Returns an escaped copy of `html`.
+    # Strings which are declared as html_safe are not escaped.
+    #
+    # @note You should prefer {escape_html_safe}, which is a safe alias that can be
+    #   used both in systems that support and don't support SafeBuffer strings.
+    #
+    # @param html [String] The string to escape
+    # @return [String] The escaped string
+    def escape_html_unless_safe(html)
+      html.html_safe? ? html : escape_html(html)
+    end
+
+    # @!method escape_html_safe(html)
+    # @overload escape_html_safe(html)
+    #   When system supports SafeBuffer string, it's an alias to #escape_html_unless_safe.
+    #   @see escape_html_unless_safe
+    # @overload escape_html_safe(html)
+    #   When system doesn't support SafeBuffer string, it's an alias to #escape_html.
+    #   @see escape_html
+    if "".respond_to?(:html_safe?)
+      alias_method :escape_html_safe, :escape_html_unless_safe
+    else
+      alias_method :escape_html_safe, :escape_html
     end
 
     # Generate unique variable name

--- a/test/filters/test_escapable.rb
+++ b/test/filters/test_escapable.rb
@@ -12,7 +12,7 @@ describe Temple::Filters::Escapable do
                    [:dynamic, "ruby_method"]]
     ]).should.equal [:multi,
       [:static, "a &lt; b"],
-      [:dynamic, "::Temple::Utils.escape_html((ruby_method))"],
+      [:dynamic, "::Temple::Utils.escape_html_safe((ruby_method))"],
     ]
   end
 
@@ -31,10 +31,9 @@ describe Temple::Filters::Escapable do
     @filter.call(exp).should.equal exp
   end
 
-  it 'should have use_html_safe option' do
+  it 'should not escape html safe statics' do
     with_html_safe do
-      filter = Temple::Filters::Escapable.new(:use_html_safe => true)
-      filter.call([:escape, true,
+      @filter.call([:escape, true,
         [:static, "a < b".html_safe]
       ]).should.equal [:static, "a < b"]
     end

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -8,12 +8,14 @@ module TestHelper
     Numeric.send(:define_method, :html_safe?) { true }
     String.send(:define_method, :html_safe?) { false }
     String.send(:define_method, :html_safe) { Temple::HTML::SafeString.new(self) }
+    Temple::Utils.send(:define_method, :escape_html_safe) { |str| escape_html_unless_safe(str) }
     yield
   ensure
     Object.send(:undef_method, :html_safe?) if Object.method_defined?(:html_safe?)
     Numeric.send(:undef_method, :html_safe?) if Numeric.method_defined?(:html_safe?)
     String.send(:undef_method, :html_safe?) if String.method_defined?(:html_safe?)
     String.send(:undef_method, :html_safe) if String.method_defined?(:html_safe)
+    Temple::Utils.send(:define_method, :escape_html_safe) { |str| escape_html(str) }
   end
 
   def grammar_validate(grammar, exp, message)

--- a/test/test_utils.rb
+++ b/test/test_utils.rb
@@ -21,17 +21,27 @@ describe Temple::Utils do
     UniqueTest.new.unique_name.should.equal '_uniquetest1'
   end
 
-  it 'has escape_html' do
+  it '#escape_html escapes unsafe html strings' do
     Temple::Utils.escape_html('<').should.equal '&lt;'
   end
 
-  it 'should escape unsafe html strings' do
+  it '#escape_html escapes safe html strings' do
+    with_html_safe do
+      Temple::Utils.escape_html('<'.html_safe).should.equal '&lt;'
+    end
+  end
+
+  it "#escape_html_safe does not fail when used with strings without html safety patch" do
+    Temple::Utils.escape_html_safe('<').should.equal '&lt;'
+  end
+
+  it '#escape_html_safe escapes unsafe html strings' do
     with_html_safe do
       Temple::Utils.escape_html_safe('<').should.equal '&lt;'
     end
   end
 
-  it 'should not escape safe html strings' do
+  it '#escape_html_safe does not escape safe html strings' do
     with_html_safe do
       Temple::Utils.escape_html_safe('<'.html_safe).should.equal '<'
     end


### PR DESCRIPTION
I belive the `use_html_safe` was introduced somewhere in [earlier versions of Slim](https://github.com/slim-template/slim/blob/d739b0005f1942584f3b49e702a5b846b6805ae0/lib/slim/compiler.rb), since then it mutated into a pure constant, which is defined during program startup (see [here](https://github.com/judofyr/temple/blob/master/lib/temple/filters/escapable.rb#L12) and [here](https://github.com/slim-template/slim/blob/master/lib/slim/splat/filter.rb#L7))

My proposal is to remove this option, because

a) no one would want to set `use_html_safe: false` if String respond_to? `html_safe?` (Rails env). This would immediately result in double string escaping and decrease overall performance,
b) it is not a responsibility of a filter to check whether a string knows about html safeness or not. This responsibility should be delegated to escaper, i.e. Temple::Utils.

`Temple::Utils.escape_html_safe` should be that common method that escapes a string and works correctly both with ActiveSupport and without it.

 `"".respond_to?(:html_safe?)` check still happens on program startup, no changes here (i.e. Temple still needs to be loaded _after_ ActiveSupport).
