### PR TITLE
fix confusing deprecation warning

### DIFF
--- a/lib/temple/html/fast.rb
+++ b/lib/temple/html/fast.rb
@@ -38,8 +38,8 @@ module Temple
         @format = options[:format]
         unless [:xhtml, :html, :xml].include?(@format)
           if @format == :html4 || @format == :html5
-            @format = :html
             warn "Format #{@format.inspect} is deprecated, use :html"
+            @format = :html
           else
             raise ArgumentError, "Invalid format #{@format.inspect}"
           end


### PR DESCRIPTION
The warning before this patch is always `Format :html is deprecated, use :html`.
