### PR TITLE
Don't overwrite buffer or add `:save_buffer` options

### DIFF
--- a/lib/temple/templates/tilt.rb
+++ b/lib/temple/templates/tilt.rb
@@ -24,8 +24,9 @@ module Temple
         opts = {}.update(self.class.options).update(options).update(file: eval_file)
         opts.delete(:mime_type)
         if opts.include?(:outvar)
-          opts[:buffer] = opts.delete(:outvar)
-          opts[:save_buffer] = true
+          #opts[:buffer] = opts.delete(:outvar)
+          #opts[:save_buffer] = true
+          opts.delete(:outvar)
         end
         @src = self.class.compile(data, opts)
       end


### PR DESCRIPTION
The `sinatra-contrib` tests were failing as of this commit: fa0da7da075c4467edd3ba35819c8b428273a984

However, since this patch also affects the `0.6.x` branch of temple..
We'd like to request a backport release as well.

I've also checked out v0.6.10 and applied the patch to a branch here:
https://github.com/zzak/temple/tree/0-6-patched

The reason we need to backport is because `slim` versions greater than 3.0.0 don't support Ruby 1.8.7, which we still support, and requires temple `~> 0.7.x`. :sob: :sob: :sob:

/cc @judofyr @minad 