### PR TITLE
Enhance visibility of the EXPRESSIONS.md file (+ wlang link)

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ Links
 * API documentation:
     * Latest Gem: <http://rubydoc.info/gems/temple/frames>
     * GitHub master: <http://rubydoc.info/github/judofyr/temple/master/frames>
+* Abstractions: <http://github.com/judofyr/temple/blob/master/EXPRESSIONS.md>
 
 Overview
 --------
@@ -123,7 +124,7 @@ continue to use the HTML abstraction. Maybe you even want to write your
 compiler in another language? Sexps are easily serialized and if you don't
 mind working across processes, it's not a problem at all.
 
-All abstractions used by Temple are documented in {file:EXPRESSIONS.md EXPRESSIONS}.
+All abstractions used by Temple are documented in [EXPRESSIONS.md](EXPRESSIONS.md).
 
 Compilers
 ---------

--- a/README.md
+++ b/README.md
@@ -253,6 +253,7 @@ Engines using Temple
 * [Sal](https://github.com/stonean/sal.rb)
 * [Temple-Mustache (Example implementation)](https://github.com/minad/temple-mustache)
 * Temple ERB example implementation (Temple::ERB::Template)
+* [WLang](https://github.com/blambeau/wlang)
 
 Acknowledgements
 ----------------


### PR DESCRIPTION
Hi!

On second thoughts, I think a very small improvement could be made by enhancing the visibility of EXPRESSIONS.md  + documentation.

On a more general tone, possibly one reason I didn't consider using much filters and generators in wlang was due to the high cost of reading through the source code to find what already existed. The README mostly contains an introduction to temple principles. As soon as you decide to rely it, what you definitely need is:
1) a list of standard abstractions (hence the first commit)
2) a list + good documentation of every filter and every generator available.

I think 2) is still completely missing (?). In addition, 1) and 2) should have much more visibility. This patch only starts that discussion.