### PR TITLE
Add .new_with_option_filter method

### DIFF
--- a/lib/temple/mixins/engine_dsl.rb
+++ b/lib/temple/mixins/engine_dsl.rb
@@ -75,9 +75,8 @@ module Temple
         define_options(filter.options.valid_keys) if respond_to?(:define_options) && filter.respond_to?(:options)
         proc do |engine|
           opts = {}.update(engine.options)
-          opts.delete_if {|k,v| !filter.options.valid_key?(k) } if filter.respond_to?(:options)
           opts.update(local_options) if local_options
-          filter.new(opts)
+          filter.new_with_option_filter(opts)
         end
       end
 

--- a/lib/temple/mixins/options.rb
+++ b/lib/temple/mixins/options.rb
@@ -44,6 +44,13 @@ module Temple
       def disable_option_validator!
         @option_validator_disabled = true
       end
+
+      def new_with_option_filter(opts = {})
+        valid_opts = opts.to_hash.select do |k, v|
+          options.valid_key?(k)
+        end
+        new(valid_opts)
+      end
     end
 
     module ThreadOptions

--- a/test/test_generator.rb
+++ b/test/test_generator.rb
@@ -73,6 +73,12 @@ describe Temple::Generator do
     ]).should.equal "VAR = BUFFER; VAR << (S:static); \n; " +
       "VAR << (D:dynamic); \n; C:code; VAR"
   end
+
+  it 'should have option filter' do
+    opts = { buffer: 'VAR', invalid: 'option' }
+    SimpleGenerator.new_with_option_filter(opts).options[:buffer].should.equal 'VAR'
+    SimpleGenerator.new_with_option_filter(opts).options.keys.include?(:invalid).should.equal false
+  end
 end
 
 describe Temple::Generators::Array do


### PR DESCRIPTION
ref: https://github.com/judofyr/temple/issues/87

I think [this line](https://github.com/slim-template/slim/blob/efaa090066c3bc2a8b0db48f4c296271148bc1e8/lib/slim/engine.rb#L38)'s aim is to skip validations for invalid options in initialization.
Initializing a generator without invalid options may be necessary in other engines, like [here](https://github.com/k0kubun/hamlit/blob/58ed547ebfc133dce4b97540a27df4d71b86c384/lib/hamlit/engine.rb#L23-L32).

You can replace:

```rb
options[:generator].new(options.to_hash.reject {|k,v| !options[:generator].options.valid_key?(k) })
```

with:

```rb
options[:generator].new_with_option_filter(options)
```