### PR TITLE
Freeze non-mutated string literals

### DIFF
--- a/lib/temple/filters/remove_bom.rb
+++ b/lib/temple/filters/remove_bom.rb
@@ -6,7 +6,7 @@ module Temple
     class RemoveBOM < Parser
       def call(s)
         return s if s.encoding.name !~ /^UTF-(8|16|32)(BE|LE)?/
-        s.gsub(Regexp.new("\\A\uFEFF".encode(s.encoding.name)), '')
+        s.gsub(Regexp.new("\\A\uFEFF".encode(s.encoding.name)), ''.freeze)
       end
     end
   end

--- a/lib/temple/generator.rb
+++ b/lib/temple/generator.rb
@@ -46,7 +46,7 @@ module Temple
     end
 
     def on_multi(*exp)
-      exp.map {|e| compile(e) }.join('; ')
+      exp.map {|e| compile(e) }.join('; '.freeze)
     end
 
     def on_newline

--- a/lib/temple/generators/rails_output_buffer.rb
+++ b/lib/temple/generators/rails_output_buffer.rb
@@ -16,7 +16,7 @@ module Temple
                      capture_generator: RailsOutputBuffer
 
       def call(exp)
-        [preamble, compile(exp), postamble].flatten.compact.join('; ')
+        [preamble, compile(exp), postamble].flatten.compact.join('; '.freeze)
       end
 
       def create_buffer

--- a/lib/temple/html/pretty.rb
+++ b/lib/temple/html/pretty.rb
@@ -26,8 +26,8 @@ module Temple
       def on_static(content)
         return [:static, content] unless @pretty
         unless @pre_tags && @pre_tags =~ content
-          content = content.sub(/\A\s*\n?/, "\n") if @indent_next
-          content = content.gsub("\n", indent)
+          content = content.sub(/\A\s*\n?/, "\n".freeze) if @indent_next
+          content = content.gsub("\n".freeze, indent)
         end
         @indent_next = false
         [:static, content]

--- a/lib/temple/mixins/dispatcher.rb
+++ b/lib/temple/mixins/dispatcher.rb
@@ -58,7 +58,7 @@ module Temple
       def replace_dispatcher(exp)
         tree = DispatchNode.new
         dispatched_methods.each do |method|
-          method.split('_')[1..-1].inject(tree) {|node, type| node[type.to_sym] }.method = method
+          method.split('_'.freeze)[1..-1].inject(tree) {|node, type| node[type.to_sym] }.method = method
         end
         self.class.class_eval %{def dispatcher(exp)
   return replace_dispatcher(exp) if self.class != #{self.class}
@@ -91,7 +91,7 @@ end}
             code = "case(exp[#{level}])\n"
             each do |key, child|
               code << "when #{key.inspect}\n  " <<
-                child.compile(level + 1, call_method).gsub("\n", "\n  ") << "\n"
+                child.compile(level + 1, call_method).gsub("\n".freeze, "\n  ".freeze) << "\n".freeze
             end
             code << "else\n  " << (call_method || 'exp') << "\nend"
           end

--- a/lib/temple/utils.rb
+++ b/lib/temple/utils.rb
@@ -54,7 +54,7 @@ module Temple
     # @return [String] Variable name
     def unique_name(prefix = nil)
       @unique_name ||= 0
-      prefix ||= (@unique_prefix ||= self.class.name.gsub('::', '_').downcase)
+      prefix ||= (@unique_prefix ||= self.class.name.gsub('::'.freeze, '_'.freeze).downcase)
       "_#{prefix}#{@unique_name += 1}"
     end
 
@@ -81,8 +81,8 @@ module Temple
       level = text.scan(/^\s*/).map(&:size).min
       text = text.gsub(/(?!\A)^\s{#{level}}/, '') if level > 0
 
-      text = text.sub(/\A\s*\n?/, "\n") if indent_next
-      text = text.gsub("\n", indent)
+      text = text.sub(/\A\s*\n?/, "\n".freeze) if indent_next
+      text = text.gsub("\n".freeze, indent)
 
       safe ? text.html_safe : text
     end


### PR DESCRIPTION
Used https://github.com/schneems/let_it_go to find easy places for `String#freeze` optimization. 

This patch reduces the number of strings allocated on EVERY request by 1040.

I used codetriage.com (which uses slim) to test.