### PR TITLE
Reduce string allocations

### DIFF
--- a/lib/temple/utils.rb
+++ b/lib/temple/utils.rb
@@ -44,7 +44,13 @@ module Temple
       # @param html [String] The string to escape
       # @return [String] The escaped string
       def escape_html(html)
-        html.to_s.gsub(ESCAPE_HTML_PATTERN, ESCAPE_HTML)
+        if html.nil?
+          "".freeze
+        else
+          result = html.to_s
+          result.gsub!(ESCAPE_HTML_PATTERN, ESCAPE_HTML)
+          result
+        end
       end
     end
 


### PR DESCRIPTION
We can modify the html string in place using `gsub` instead of allocating a new string.

This may be a breaking change (since String#to_s returns itself), but the tests still pass...

On my app I'm seeing 1843 fewer objects and 68,992 bytes saved per request.

For really minor gains, we can check if an element is nil and return a frozen empty string. This gives us a savings of 95 objects.

It looks like there are possibly more savings here, but they'll be a bit harder to get at

```
      1776  "&|\"|'|<|>"
      1776  /Users/richardschneeman/Documents/projects/temple/lib/temple/utils.rb:51
```

It looks like gsub! and gub both allocates strings internally when using hash arguments. It might be worth looking into how loofah does sanitization, or maybe looking into alternate ways to do the sanitization.