### PR TITLE
Generators should not be affected by `$,` value

### DIFF
--- a/lib/temple/generators/array_buffer.rb
+++ b/lib/temple/generators/array_buffer.rb
@@ -5,7 +5,7 @@ module Temple
     #   _buf = []
     #   _buf << "static"
     #   _buf << dynamic
-    #   _buf.join
+    #   _buf.join("")
     #
     # @api public
     class ArrayBuffer < Array
@@ -21,7 +21,8 @@ module Temple
       end
 
       def return_buffer
-        "#{buffer} = #{buffer}.join"
+        freeze = options[:freeze_static] ? '.freeze' : ''
+        "#{buffer} = #{buffer}.join(\"\"#{freeze})"
       end
     end
   end

--- a/lib/temple/generators/erb.rb
+++ b/lib/temple/generators/erb.rb
@@ -9,7 +9,7 @@ module Temple
       end
 
       def on_multi(*exp)
-        exp.map {|e| compile(e) }.join
+        exp.map {|e| compile(e) }.join('')
       end
 
       def on_capture(name, exp)

--- a/test/test_generator.rb
+++ b/test/test_generator.rb
@@ -97,16 +97,16 @@ describe Temple::Generators::ArrayBuffer do
     gen = Temple::Generators::ArrayBuffer.new(freeze_static: false)
     gen.call([:static,  'test']).should.equal '_buf = "test"'
     gen.call([:dynamic, 'test']).should.equal '_buf = (test).to_s'
-    gen.call([:code,    'test']).should.equal '_buf = []; test; _buf = _buf.join'
+    gen.call([:code,    'test']).should.equal '_buf = []; test; _buf = _buf.join("")'
 
-    gen.call([:multi, [:static, 'a'], [:static,  'b']]).should.equal '_buf = []; _buf << ("a"); _buf << ("b"); _buf = _buf.join'
-    gen.call([:multi, [:static, 'a'], [:dynamic, 'b']]).should.equal '_buf = []; _buf << ("a"); _buf << (b); _buf = _buf.join'
+    gen.call([:multi, [:static, 'a'], [:static,  'b']]).should.equal '_buf = []; _buf << ("a"); _buf << ("b"); _buf = _buf.join("")'
+    gen.call([:multi, [:static, 'a'], [:dynamic, 'b']]).should.equal '_buf = []; _buf << ("a"); _buf << (b); _buf = _buf.join("")'
   end
 
   it 'should freeze static' do
     gen = Temple::Generators::ArrayBuffer.new(freeze_static: true)
     gen.call([:static,  'test']).should.equal '_buf = "test"'
-    gen.call([:multi, [:dynamic, '1'], [:static,  'test']]).should.equal '_buf = []; _buf << (1); _buf << ("test".freeze); _buf = _buf.join'
+    gen.call([:multi, [:dynamic, '1'], [:static,  'test']]).should.equal '_buf = []; _buf << (1); _buf << ("test".freeze); _buf = _buf.join("".freeze)'
   end
 end
 


### PR DESCRIPTION
`Array#join` is equivalent to `Array#join($,)` . Explicitly give an
empty string in order to avoid `$,` effect.