### PR TITLE
Create Temple::Filters::StringSplitter

### DIFF
--- a/lib/temple.rb
+++ b/lib/temple.rb
@@ -44,6 +44,7 @@ module Temple
     autoload :ControlFlow,        'temple/filters/control_flow'
     autoload :MultiFlattener,     'temple/filters/multi_flattener'
     autoload :StaticMerger,       'temple/filters/static_merger'
+    autoload :StringSplitter,     'temple/filters/string_splitter'
     autoload :DynamicInliner,     'temple/filters/dynamic_inliner'
     autoload :Escapable,          'temple/filters/escapable'
     autoload :Eraser,             'temple/filters/eraser'

--- a/lib/temple/filters/string_splitter.rb
+++ b/lib/temple/filters/string_splitter.rb
@@ -13,7 +13,7 @@ module Temple
           def compile(code)
             [].tap do |exps|
               tokens = Ripper.lex(code.strip)
-              tokens.pop while tokens.last && %i[on_comment on_sp].include?(tokens.last[1])
+              tokens.pop while tokens.last && [:on_comment, :on_sp].include?(tokens.last[1])
 
               if tokens.size < 2
                 raise "Expected token size >= 2 but got: #{tokens.size}"

--- a/lib/temple/filters/string_splitter.rb
+++ b/lib/temple/filters/string_splitter.rb
@@ -7,7 +7,7 @@ module Temple
       rescue LoadError
       end
 
-      if defined?(Ripper)
+      if defined?(Ripper) && RUBY_VERSION >= "2.0.0"
         class << self
           # `code` param must be valid string literal
           def compile(code)

--- a/lib/temple/filters/string_splitter.rb
+++ b/lib/temple/filters/string_splitter.rb
@@ -1,0 +1,130 @@
+module Temple
+  module Filters
+    # Compile [:dynamic, "foo#{bar}"] to [:multi, [:static, 'foo'], [:dynamic, 'bar']]
+    class StringSplitter < Filter
+      begin
+        require 'ripper'
+      rescue LoadError
+      end
+
+      if defined?(Ripper)
+        class << self
+          # `code` param must be valid string literal
+          def compile(code)
+            [].tap do |exps|
+              tokens = Ripper.lex(code.strip)
+              tokens.pop while tokens.last && %i[on_comment on_sp].include?(tokens.last[1])
+
+              if tokens.size < 2
+                raise "Expected token size >= 2 but got: #{tokens.size}"
+              end
+              compile_tokens!(exps, tokens)
+            end
+          end
+
+          private
+
+          def strip_quotes!(tokens)
+            _, type, beg_str = tokens.shift
+            if type != :on_tstring_beg
+              raise "Expected :on_tstring_beg but got: #{type}"
+            end
+
+            _, type, end_str = tokens.pop
+            if type != :on_tstring_end
+              raise "Expected :on_tstring_end but got: #{type}"
+            end
+
+            [beg_str, end_str]
+          end
+
+          def compile_tokens!(exps, tokens)
+            beg_str, end_str = strip_quotes!(tokens)
+
+            until tokens.empty?
+              _, type, str = tokens.shift
+
+              case type
+              when :on_tstring_content
+                exps << [:static, eval("#{beg_str}#{str}#{end_str}").to_s]
+              when :on_embexpr_beg
+                embedded = shift_balanced_embexpr(tokens)
+                exps << [:dynamic, embedded] unless embedded.empty?
+              end
+            end
+          end
+
+          def shift_balanced_embexpr(tokens)
+            String.new.tap do |embedded|
+              embexpr_open = 1
+
+              until tokens.empty?
+                _, type, str = tokens.shift
+                case type
+                when :on_embexpr_beg
+                  embexpr_open += 1
+                when :on_embexpr_end
+                  embexpr_open -= 1
+                  break if embexpr_open == 0
+                end
+
+                embedded << str
+              end
+            end
+          end
+        end
+
+        def on_dynamic(code)
+          return [:dynamic, code] unless string_literal?(code)
+          return [:dynamic, code] if code.include?("\n")
+
+          temple = [:multi]
+          StringSplitter.compile(code).each do |type, content|
+            case type
+            when :static
+              temple << [:static, content]
+            when :dynamic
+              temple << on_dynamic(content)
+            end
+          end
+          temple
+        end
+
+        private
+
+        def string_literal?(code)
+          return false if SyntaxChecker.syntax_error?(code)
+
+          type, instructions = Ripper.sexp(code)
+          return false if type != :program
+          return false if instructions.size > 1
+
+          type, _ = instructions.first
+          type == :string_literal
+        end
+
+        class SyntaxChecker < Ripper
+          class ParseError < StandardError; end
+
+          def self.syntax_error?(code)
+            self.new(code).parse
+            false
+          rescue ParseError
+            true
+          end
+
+          private
+
+          def on_parse_error(*)
+            raise ParseError
+          end
+        end
+      else
+        # Do nothing if ripper is unavailable
+        def call(ast)
+          ast
+        end
+      end
+    end
+  end
+end

--- a/test/filters/test_string_splitter.rb
+++ b/test/filters/test_string_splitter.rb
@@ -4,7 +4,7 @@ begin
 rescue LoadError
 end
 
-if defined?(Ripper)
+if defined?(Ripper) && RUBY_VERSION >= "2.0.0"
   describe Temple::Filters::StringSplitter do
     before do
       @filter = Temple::Filters::StringSplitter.new

--- a/test/filters/test_string_splitter.rb
+++ b/test/filters/test_string_splitter.rb
@@ -1,0 +1,18 @@
+require 'helper'
+begin
+  require 'ripper'
+rescue LoadError
+end
+
+if defined?(Ripper)
+  describe Temple::Filters::StringSplitter do
+    before do
+      @filter = Temple::Filters::StringSplitter.new
+    end
+
+    it 'should split :dynamic with string literal' do
+      @filter.call([:dynamic, '"static#{dynamic}"']
+      ).should.equal [:multi, [:static, 'static'], [:dynamic, 'dynamic']]
+    end
+  end
+end


### PR DESCRIPTION
Extract Hamlit::StringSplitter filter from [Hamlit](https://github.com/k0kubun/hamlit), which splits `:dynamic` with string interpolation into some `:dynamic` and `:static`.
You can utilize some optimizers for `:static` by this filter.