### PR TITLE
Add support for Ruby 2.3 native CGI.escapeHTML

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ rvm:
   - 1.9.3
   - 2.0.0
   - 2.1.0
+  - 2.3.0
   - ruby-head
   - jruby-19mode
   - rbx-2
@@ -13,3 +14,8 @@ sudo: false
 matrix:
   allow_failures:
     - rvm: ruby-head
+  include:
+    - rvm: 2.1.0
+      gemfile: gemfiles/Gemfile.escape_utils
+    - rvm: 2.3.0
+      gemfile: gemfiles/Gemfile.escape_utils

--- a/gemfiles/Gemfile.escape_utils
+++ b/gemfiles/Gemfile.escape_utils
@@ -1,0 +1,4 @@
+source 'https://rubygems.org/'
+
+gemspec path:'../'
+gem 'escape_utils'

--- a/gemfiles/Gemfile.escape_utils.lock
+++ b/gemfiles/Gemfile.escape_utils.lock
@@ -1,0 +1,27 @@
+PATH
+  remote: ../
+  specs:
+    temple (0.7.6)
+
+GEM
+  remote: https://rubygems.org/
+  specs:
+    bacon (1.2.0)
+    erubis (2.7.0)
+    escape_utils (1.2.0)
+    rake (10.5.0)
+    tilt (2.0.2)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  bacon
+  erubis
+  escape_utils
+  rake
+  temple!
+  tilt
+
+BUNDLED WITH
+   1.11.2

--- a/lib/temple/utils.rb
+++ b/lib/temple/utils.rb
@@ -1,8 +1,15 @@
 begin
+  require 'cgi/escape'
+rescue LoadError
+  # Loading CGI Escape failed
+end
+
+begin
   require 'escape_utils'
 rescue LoadError
   # Loading EscapeUtils failed
 end
+
 
 module Temple
   # @api public
@@ -25,6 +32,14 @@ module Temple
       # @return [String] The escaped string
       def escape_html(html)
         EscapeUtils.escape_html(html.to_s, false)
+      end
+    elsif defined?(CGI.escapeHTML)
+      # Returns an escaped copy of `html`.
+      #
+      # @param html [String] The string to escape
+      # @return [String] The escaped string
+      def escape_html(html)
+        CGI.escapeHTML(html.to_s)
       end
     else
       # Used by escape_html


### PR DESCRIPTION
Added in support for Ruby 2.3 native CGI.escapeHTML method.
 #97 