### PR TITLE
Fix a warning in StaticAnalyzer

### DIFF
--- a/lib/temple/filters/static_analyzer.rb
+++ b/lib/temple/filters/static_analyzer.rb
@@ -35,7 +35,7 @@ module Temple
           return false if code.nil? || code.strip.empty?
           return false if SyntaxChecker.syntax_error?(code)
 
-          Ripper.lex(code).each do |(_, col), token, str|
+          Ripper.lex(code).each do |_, token, str|
             case token
             when *STATIC_TOKENS
               # noop


### PR DESCRIPTION
I fixed a following warning introduced in https://github.com/judofyr/temple/pull/95. I hope this will be released as v0.7.8.

```
temple/lib/temple/filters/static_analyzer.rb:38: warning: assigned but unused variable - col
```

By the way, Haml's master uses Temple now! :beer: 