### PR TITLE
Carve out Temple::StaticAnalyzer from Temple::Filters::StaticAnalyzer

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,6 +1,7 @@
 0.8.0
 
   * Add Temple::StaticAnalyzer to analyze Ruby expressions
+  * Support newlines in Temple::Filters::StaticAnalyzer
 
 0.7.8
 
@@ -8,7 +9,7 @@
 
 0.7.7
 
-  * Add StaticAnalyzer, StringSplitter filters
+  * Add Temple::Filters::StaticAnalyzer, Temple::Filters::StringSplitter
   * Freeze string literals
 
 0.7.6

--- a/CHANGES
+++ b/CHANGES
@@ -1,10 +1,14 @@
+0.8.0
+
+  * Add Temple::StaticAnalyzer to analyze Ruby expressions
+
 0.7.8
 
   * Fix an warning in StaticAnalyzer
 
 0.7.7
 
-  * Add StaticAnalyzer, StringSplitter
+  * Add StaticAnalyzer, StringSplitter filters
   * Freeze string literals
 
 0.7.6

--- a/lib/temple.rb
+++ b/lib/temple.rb
@@ -13,6 +13,7 @@ module Temple
   autoload :ImmutableMap,         'temple/map'
   autoload :MutableMap,           'temple/map'
   autoload :OptionMap,            'temple/map'
+  autoload :StaticAnalyzer,       'temple/static_analyzer'
 
   module Mixins
     autoload :Dispatcher,         'temple/mixins/dispatcher'

--- a/lib/temple/filters/static_analyzer.rb
+++ b/lib/temple/filters/static_analyzer.rb
@@ -1,85 +1,21 @@
-begin
-  require 'ripper'
-rescue LoadError
-end
-
 module Temple
   module Filters
     # Convert [:dynamic, code] to [:static, text] if code is static Ruby expression.
     class StaticAnalyzer < Filter
-      STATIC_TOKENS = [
-        :on_tstring_beg, :on_tstring_end, :on_tstring_content,
-        :on_embexpr_beg, :on_embexpr_end,
-        :on_lbracket, :on_rbracket,
-        :on_qwords_beg, :on_words_sep, :on_qwords_sep,
-        :on_lparen, :on_rparen,
-        :on_lbrace, :on_rbrace, :on_label,
-        :on_int, :on_float, :on_imaginary,
-        :on_comma, :on_sp,
-      ].freeze
-
-      DYNAMIC_TOKENS = [
-        :on_ident, :on_period,
-      ].freeze
-
-      STATIC_KEYWORDS = [
-        'true', 'false', 'nil',
-      ].freeze
-
-      STATIC_OPERATORS = [
-        '=>',
-      ].freeze
-
-      if defined?(Ripper)
-        def self.static?(code)
-          return false if code.nil? || code.strip.empty?
-          return false if SyntaxChecker.syntax_error?(code)
-
-          Ripper.lex(code).each do |_, token, str|
-            case token
-            when *STATIC_TOKENS
-              # noop
-            when :on_kw
-              return false unless STATIC_KEYWORDS.include?(str)
-            when :on_op
-              return false unless STATIC_OPERATORS.include?(str)
-            when *DYNAMIC_TOKENS
-              return false
-            else
-              return false
-            end
-          end
-          true
-        end
-
-        def on_dynamic(code)
-          if StaticAnalyzer.static?(code)
-            [:static, eval(code).to_s]
-          else
-            [:dynamic, code]
-          end
-        end
-
-        class SyntaxChecker < Ripper
-          class ParseError < StandardError; end
-
-          def self.syntax_error?(code)
-            self.new(code).parse
-            false
-          rescue ParseError
-            true
-          end
-
-          private
-
-          def on_parse_error(*)
-            raise ParseError
-          end
-        end
-      else
-        # Do nothing if ripper is unavailable
-        def call(ast)
+      def call(ast)
+        # Optimize only when Ripper is available.
+        if ::Temple::StaticAnalyzer.available?
+          super
+        else
           ast
+        end
+      end
+
+      def on_dynamic(code)
+        if ::Temple::StaticAnalyzer.static?(code)
+          [:static, eval(code).to_s]
+        else
+          [:dynamic, code]
         end
       end
     end

--- a/lib/temple/filters/static_analyzer.rb
+++ b/lib/temple/filters/static_analyzer.rb
@@ -2,18 +2,25 @@ module Temple
   module Filters
     # Convert [:dynamic, code] to [:static, text] if code is static Ruby expression.
     class StaticAnalyzer < Filter
-      def call(ast)
+      def call(exp)
         # Optimize only when Ripper is available.
         if ::Temple::StaticAnalyzer.available?
           super
         else
-          ast
+          exp
         end
       end
 
       def on_dynamic(code)
         if ::Temple::StaticAnalyzer.static?(code)
-          [:static, eval(code).to_s]
+          exp = [:static, eval(code).to_s]
+
+          newlines = code.count("\n")
+          if newlines == 0
+            exp
+          else
+            [:multi, exp, *newlines.times.map { [:newline] }]
+          end
         else
           [:dynamic, code]
         end

--- a/lib/temple/static_analyzer.rb
+++ b/lib/temple/static_analyzer.rb
@@ -13,7 +13,7 @@ module Temple
       :on_lparen, :on_rparen,
       :on_lbrace, :on_rbrace, :on_label,
       :on_int, :on_float, :on_imaginary,
-      :on_comma, :on_sp,
+      :on_comma, :on_sp, :on_ignored_nl,
     ].freeze
 
     DYNAMIC_TOKENS = [

--- a/lib/temple/static_analyzer.rb
+++ b/lib/temple/static_analyzer.rb
@@ -1,0 +1,77 @@
+begin
+  require 'ripper'
+rescue LoadError
+end
+
+module Temple
+  module StaticAnalyzer
+    STATIC_TOKENS = [
+      :on_tstring_beg, :on_tstring_end, :on_tstring_content,
+      :on_embexpr_beg, :on_embexpr_end,
+      :on_lbracket, :on_rbracket,
+      :on_qwords_beg, :on_words_sep, :on_qwords_sep,
+      :on_lparen, :on_rparen,
+      :on_lbrace, :on_rbrace, :on_label,
+      :on_int, :on_float, :on_imaginary,
+      :on_comma, :on_sp,
+    ].freeze
+
+    DYNAMIC_TOKENS = [
+      :on_ident, :on_period,
+    ].freeze
+
+    STATIC_KEYWORDS = [
+      'true', 'false', 'nil',
+    ].freeze
+
+    STATIC_OPERATORS = [
+      '=>',
+    ].freeze
+
+    class << self
+      def available?
+        defined?(Ripper)
+      end
+
+      def static?(code)
+        return false if code.nil? || code.strip.empty?
+        return false if syntax_error?(code)
+
+        Ripper.lex(code).each do |_, token, str|
+          case token
+          when *STATIC_TOKENS
+            # noop
+          when :on_kw
+            return false unless STATIC_KEYWORDS.include?(str)
+          when :on_op
+            return false unless STATIC_OPERATORS.include?(str)
+          when *DYNAMIC_TOKENS
+            return false
+          else
+            return false
+          end
+        end
+        true
+      end
+
+      def syntax_error?(code)
+        SyntaxChecker.new(code).parse
+        false
+      rescue SyntaxChecker::ParseError
+        true
+      end
+    end
+
+    if defined?(Ripper)
+      class SyntaxChecker < Ripper
+        class ParseError < StandardError; end
+
+        private
+
+        def on_parse_error(*)
+          raise ParseError
+        end
+      end
+    end
+  end
+end

--- a/test/filters/test_static_analyzer.rb
+++ b/test/filters/test_static_analyzer.rb
@@ -3,6 +3,7 @@ require 'helper'
 describe Temple::Filters::StaticAnalyzer do
   before do
     @filter = Temple::Filters::StaticAnalyzer.new
+    @generator = Temple::Generator.new
   end
 
   if Temple::StaticAnalyzer.available?
@@ -14,6 +15,14 @@ describe Temple::Filters::StaticAnalyzer do
     it 'should not convert :dynamic if code is dynamic' do
       exp = [:dynamic, '"#{hello}#{100}"']
       @filter.call(exp).should.equal(exp)
+    end
+
+    it 'should not change number of newlines in generated code' do
+      exp = [:dynamic, "[100,\n200,\n]"]
+      @filter.call(exp).should.equal([:multi, [:static, '[100, 200]'], [:newline], [:newline]])
+
+      @generator.call(@filter.call(exp)).count("\n").
+        should.equal(@generator.call(exp).count("\n"))
     end
   else
     it 'should do nothing' do

--- a/test/filters/test_static_analyzer.rb
+++ b/test/filters/test_static_analyzer.rb
@@ -1,15 +1,11 @@
 require 'helper'
-begin
-  require 'ripper'
-rescue LoadError
-end
 
-if defined?(Ripper)
-  describe Temple::Filters::StaticAnalyzer do
-    before do
-      @filter = Temple::Filters::StaticAnalyzer.new
-    end
+describe Temple::Filters::StaticAnalyzer do
+  before do
+    @filter = Temple::Filters::StaticAnalyzer.new
+  end
 
+  if Temple::StaticAnalyzer.available?
     it 'should convert :dynamic to :static if code is static' do
       @filter.call([:dynamic, '"#{"hello"}#{100}"']
       ).should.equal [:static, 'hello100']
@@ -18,6 +14,15 @@ if defined?(Ripper)
     it 'should not convert :dynamic if code is dynamic' do
       exp = [:dynamic, '"#{hello}#{100}"']
       @filter.call(exp).should.equal(exp)
+    end
+  else
+    it 'should do nothing' do
+      [
+        [:dynamic, '"#{"hello"}#{100}"'],
+        [:dynamic, '"#{hello}#{100}"'],
+      ].each do |exp|
+        @filter.call(exp).should.equal(exp)
+      end
     end
   end
 end

--- a/test/test_static_analyzer.rb
+++ b/test/test_static_analyzer.rb
@@ -10,7 +10,7 @@ describe Temple::StaticAnalyzer do
   if Temple::StaticAnalyzer.available?
     describe '.static?' do
       it 'should return true if given Ruby expression is static' do
-        ['true', 'false', '"hello world"', "[1, { 2 => 3 }]"].each do |exp|
+        ['true', 'false', '"hello world"', "[1, { 2 => 3 }]", "[\n1,\n]"].each do |exp|
           Temple::StaticAnalyzer.static?(exp).should.equal(true)
         end
       end

--- a/test/test_static_analyzer.rb
+++ b/test/test_static_analyzer.rb
@@ -1,0 +1,39 @@
+require 'helper'
+
+describe Temple::StaticAnalyzer do
+  describe '.available?' do
+    it 'should return true if its dependency is available' do
+      Temple::StaticAnalyzer.available?.should.equal(defined?(Ripper))
+    end
+  end
+
+  if Temple::StaticAnalyzer.available?
+    describe '.static?' do
+      it 'should return true if given Ruby expression is static' do
+        ['true', 'false', '"hello world"', "[1, { 2 => 3 }]"].each do |exp|
+          Temple::StaticAnalyzer.static?(exp).should.equal(true)
+        end
+      end
+
+      it 'should return false if given Ruby expression is dynamic' do
+        ['1 + 2', 'variable', 'method_call(a)', 'CONSTANT'].each do |exp|
+          Temple::StaticAnalyzer.static?(exp).should.equal(false)
+        end
+      end
+    end
+
+    describe '.syntax_error?' do
+      it 'should return false if given Ruby expression is valid' do
+        ['Foo.bar.baz { |c| c.d! }', '{ foo: bar }'].each do |exp|
+          Temple::StaticAnalyzer.syntax_error?(exp).should.equal(false)
+        end
+      end
+
+      it 'should return true if given Ruby expression is invalid' do
+        ['Foo.bar.baz { |c| c.d! ', ' foo: bar '].each do |exp|
+          Temple::StaticAnalyzer.syntax_error?(exp).should.equal(true)
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Background
I have this kind of utility in both Hamlit and new Haml branch. I haven't used these methods (Of course I use the Temple filter itself.) from Hamlit because I put this in deep namespace in https://github.com/judofyr/temple/pull/95. Now I need to reinvent this in Haml too.

## Changes
Since this is also convenient for template engine's language-specific optimization, I want to make this tool available globally. Also, I added `.available?` method to check availability easily.