### PR TITLE
Fixed depreciated tilt template mime type

### DIFF
--- a/lib/temple/templates/tilt.rb
+++ b/lib/temple/templates/tilt.rb
@@ -7,14 +7,6 @@ module Temple
 
       define_options mime_type: 'text/html'
 
-      def self.default_mime_type
-        options[:mime_type]
-      end
-
-      def self.default_mime_type=(mime_type)
-        options[:mime_type] = mime_type
-      end
-
       # Prepare Temple template
       #
       # Called immediately after template data is loaded.
@@ -22,7 +14,7 @@ module Temple
       # @return [void]
       def prepare
         opts = {}.update(self.class.options).update(options).update(file: eval_file)
-        opts.delete(:mime_type)
+        metadata[:mime_type] = opts.delete(:mime_type)
         if opts.include?(:outvar)
           opts[:buffer] = opts.delete(:outvar)
           opts[:save_buffer] = true


### PR DESCRIPTION
https://github.com/rtomayko/tilt/blob/master/lib/tilt/template.rb

Tilt templates now prefer using metadata[:mime_type] to expose the mime type of a template. This is causing templates like slim to not have a mime type in the metadata, although it can still be accessed through the depreciated default_mime_type