### PR TITLE
WIP: Always escape quotes in html attribute values

### DIFF
--- a/lib/temple/html/fast.rb
+++ b/lib/temple/html/fast.rb
@@ -110,7 +110,7 @@ module Temple
         else
           [:multi,
            [:static, " #{name}=#{options[:attr_quote]}"],
-           compile(value),
+           quote_html(compile(value)),
            [:static, options[:attr_quote]]]
         end
       end
@@ -123,6 +123,19 @@ module Temple
            [:static, @js_wrapper.last]]
         else
           compile(content)
+        end
+      end
+
+      private
+
+      def quote_html(expr)
+        case expr[0]
+        when :static
+          [:static, ::Temple::Utils.quote_html(expr[1])]
+        when :dynamic
+          [:dynamic, "::Temple::Utils.quote_html((#{expr[1]}))"]
+        else
+          expr.map { |val| val.is_a?(Array) ? quote_html(val) : val }
         end
       end
     end

--- a/lib/temple/utils.rb
+++ b/lib/temple/utils.rb
@@ -59,6 +59,10 @@ module Temple
       end
     end
 
+    def quote_html(string)
+      string.to_s.gsub(/["']/, '"' => '&quot;'.freeze, "'" => '&#39;'.freeze)
+    end
+
     # Generate unique variable name
     #
     # @param prefix [String] Variable name prefix

--- a/test/html/test_fast.rb
+++ b/test/html/test_fast.rb
@@ -74,7 +74,22 @@ describe Temple::HTML::Fast do
                      [:static, "<div"],
                      [:multi,
                       [:multi, [:static, " id=\""], [:static, "test"], [:static, '"']],
-                      [:multi, [:static, " class=\""], [:dynamic, "block"], [:static, '"']]],
+                      [:multi, [:static, " class=\""], [:dynamic, "::Temple::Utils.quote_html((block))"], [:static, '"']]],
+                     [:static, ">"],
+                     [:content],
+                     [:static, "</div>"]]
+  end
+
+  it 'should correctly escape quotes in html with static attrs' do
+    @html.call([:html, :tag,
+      'div',
+      [:html, :attrs,
+       [:html, :attr, 'id', [:static, '"\'test"']]],
+       [:content]
+    ]).should.equal [:multi,
+                     [:static, "<div"],
+                     [:multi,
+                      [:multi, [:static, " id=\""], [:static, "&quot;&#39;test&quot;"], [:static, '"']]],
                      [:static, ">"],
                      [:content],
                      [:static, "</div>"]]


### PR DESCRIPTION
By having quotes inside html attribute values, the generated html code
can get wrong. For example

```ruby
[:html, :tag, 'div',
  [:html, :attrs, [
    [:html, :attr, 'data-something', [:static, '"test']]
  ], [:content]
]
```

compiles to

```html
<div data-something=""test"></div>
```

Notice the `"` closes `data-something` which obviously is not intended.
To fix this, all quotes now always get escaped, so generated code
becomes:

```html
<div data-something="&quot;test"></div>
```

`"` is escaped to `&quot;` and `'` is escaped to `&#34`, so both
delimiters can be used.

---

The idea to fix this originates from using Slim and the issue https://github.com/slim-template/slim/issues/464.

The fix is based on https://groups.google.com/forum/#!topic/ruby-security-ann/8B2iV2tPRSE, where Ruby on Rails fixed their generators by always escaping `"` with `&quot;` regardless whether it is `html_safe?` or not. I just made sure both delimiters (`"` and `'`) are escaped.

It is WIP because I am not sure if the current implementation is the cleanest/fastest. Maybe someone with more experience in hacking Temple can suggest a cleaner/simpler way to do it.

By having this fixed in Temple, all libraries generating HTML automatically get this fix. Otherwise each library would have to make sure the quotes are correctly escaped.

I'm not 100 % sure if there are any side effects of this (eg. HTML code being valid wo this PR gets invalid), but a quick test on my side revealed no errors.