### PR TITLE
Fix issue with --enable-frozen-string-literal

### DIFF
--- a/lib/temple/mixins/dispatcher.rb
+++ b/lib/temple/mixins/dispatcher.rb
@@ -90,7 +90,8 @@ module Temple
             raise 'Invalid dispatcher node' unless method
             call_method
           else
-            code = "case(exp[#{level}])\n"
+            code = String.new
+            code << "case(exp[#{level}])\n"
             each do |key, child|
               code << "when #{key.inspect}\n  " <<
                 child.compile(level + 1, call_method).gsub("\n".freeze, "\n  ".freeze) << "\n".freeze


### PR DESCRIPTION
This is the minimum change necessary to allow Roda's specs to work,
there may be other cases that need to be fixed for
--enable-frozen-string-literal to work.