### PR TITLE
Change default :capture_generator to self

### DIFF
--- a/lib/temple/generator.rb
+++ b/lib/temple/generator.rb
@@ -10,7 +10,7 @@ module Temple
     include Mixins::Options
 
     define_options :save_buffer,
-                   capture_generator: 'StringBuffer',
+                   capture_generator: self,
                    buffer: '_buf',
                    freeze_static: RUBY_VERSION >= '2.1'
 


### PR DESCRIPTION
Currently when you want to always use ArrayBuffer generator, you must define it like this:

    Engine.new(generator: Generators::ArrayBuffer.new(capture_generator: 'ArrayBuffer'))

I’d expect that `ArrayBuffer` will implicitly use `ArrayBuffer` even for captures, not `StringBuffer`. The current behaviour is IMO very confusing and inconvenient.

This commit changes the default :capture_generator to `self`, i.e. the same type of generator will be used for captures by default.

    Engine.new(generator: Generators::ArrayBuffer)