### PR TITLE
prevent duplicating newlines in ERB outupt.

### DIFF
--- a/lib/temple/generators/erb.rb
+++ b/lib/temple/generators/erb.rb
@@ -27,6 +27,10 @@ module Temple
       def on_code(code)
         "<% #{code} %>"
       end
+
+      def on_newline
+        '' # prevent duplicating newlines!
+      end
     end
   end
 end


### PR DESCRIPTION
* it destroys preformatted text