### PR TITLE
Update Rails template for 6.0

### DIFF
--- a/lib/temple/templates/rails.rb
+++ b/lib/temple/templates/rails.rb
@@ -3,9 +3,9 @@ module Temple
     class Rails
       extend Mixins::Template
 
-      def call(template)
+      def call(template, source = nil)
         opts = {}.update(self.class.options).update(file: template.identifier)
-        self.class.compile(template.source, opts)
+        self.class.compile((source || template.source), opts)
       end
 
       def supports_streaming?


### PR DESCRIPTION
Running Temple in Rails 6 triggers a deprecation warning:
```
DEPRECATION WARNING: Single arity template handlers are deprecated.  Template handlers must
now accept two parameters, the view object and the source for the view object.
Change:
  >> #<Class:0x000000010f6c1c80>#call(template)
To:
  >> #<Class:0x000000010f6c1c80>#call(template, source)
```

This is because of a recent change to Rails (https://github.com/rails/rails/pull/35119) that attempts to make template handlers read-only.

This PR removes the deprecated (“old-style”) handler for Rails 6 projects, while maintaining compatibility with older versions of Rails (3.1-5.2).