### PR TITLE
Remove gemnasium badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 Temple
 ======
 
-[![Build Status](https://secure.travis-ci.org/judofyr/temple.svg?branch=master)](http://travis-ci.org/judofyr/temple) [![Dependency Status](https://gemnasium.com/judofyr/temple.svg?travis)](https://gemnasium.com/judofyr/temple) [![Code Climate](https://codeclimate.com/github/judofyr/temple.svg)](https://codeclimate.com/github/judofyr/temple) [![Gem Version](https://badge.fury.io/rb/temple.svg)](https://rubygems.org/gems/temple)
+[![Build Status](https://secure.travis-ci.org/judofyr/temple.svg?branch=master)](http://travis-ci.org/judofyr/temple) [![Code Climate](https://codeclimate.com/github/judofyr/temple.svg)](https://codeclimate.com/github/judofyr/temple) [![Gem Version](https://badge.fury.io/rb/temple.svg)](https://rubygems.org/gems/temple)
 
 Temple is an abstraction and a framework for compiling templates to pure Ruby.
 It's all about making it easier to experiment, implement and optimize template


### PR DESCRIPTION
The Gemnasium badge no longer works, as [the service was shutdown after being acquired by GitLab](https://docs.gitlab.com/ee/user/project/import/gemnasium.html).