### PR TITLE
Check html_safe? of to_s

### DIFF
--- a/lib/temple/utils.rb
+++ b/lib/temple/utils.rb
@@ -18,6 +18,8 @@ module Temple
     # @param html [String] The string to escape
     # @return [String] The escaped string
     def escape_html_safe(html)
+      return html if html.html_safe?
+      html = html.to_s
       html.html_safe? ? html : escape_html(html)
     end
 

--- a/test/test_utils.rb
+++ b/test/test_utils.rb
@@ -4,6 +4,11 @@ class UniqueTest
   include Temple::Utils
 end
 
+HtmlStringObject = Struct.new(:to_s, :is_html_safe) do
+  # HACK Ruby 1.9.3 doesn't support `?` in Struct member names
+  alias html_safe? is_html_safe
+end
+
 describe Temple::Utils do
   it 'has empty_exp?' do
     Temple::Utils.empty_exp?([:multi]).should.be.true
@@ -31,9 +36,30 @@ describe Temple::Utils do
     end
   end
 
+  it 'should escape unsafe html objects' do
+    with_html_safe do
+      object = HtmlStringObject.new('<', false)
+      Temple::Utils.escape_html_safe(object).should.equal '&lt;'
+    end
+  end
+
   it 'should not escape safe html strings' do
     with_html_safe do
       Temple::Utils.escape_html_safe('<'.html_safe).should.equal '<'
+    end
+  end
+
+  it 'should not escape safe html objects' do
+    with_html_safe do
+      object = HtmlStringObject.new('<', true)
+      Temple::Utils.escape_html_safe(object).should.equal object
+    end
+  end
+
+  it 'should not escape safe html Object#to_s values' do
+    with_html_safe do
+      object = HtmlStringObject.new('<'.html_safe, false)
+      Temple::Utils.escape_html_safe(object).should.equal '<'
     end
   end
 end


### PR DESCRIPTION
`Object#to_s` may return an HTML-safe string even though `Object#html_safe?` returns false.

(Because Temple defines `Object#html_safe?`, it may not be a reliable source of truth when dealing with objects from other frameworks, such as Rails' `ActionText::RichText`.)

Fixes slim-template/slim#822.
Fixes rails/rails#36955.