### PR TITLE
Suppress deprecated warning by Object#=~ since ruby 2.6

### DIFF
--- a/lib/temple/mixins/grammar_dsl.rb
+++ b/lib/temple/mixins/grammar_dsl.rb
@@ -143,7 +143,8 @@ module Temple
           start = Or.new(self)
           curr = [start]
           rule.each do |elem|
-            if elem =~ /^(.*)(\*|\?|\+)$/
+            case elem
+            when /^(.*)(\*|\?|\+)$/
               elem = Element.new(self, const_get($1))
               curr.each {|c| c << elem }
               elem << elem if $2 != '?'


### PR DESCRIPTION
In `Temple::Mixins::GrammerDSL::Value#Rule`, call `=~` method to `Class` class then that causes a warning message.
This behavior introduced from ruby 2.6 with `-W` option.
(And ruby 2.7 always show a warning message)

https://bugs.ruby-lang.org/issues/15231
https://github.com/ruby/ruby/commit/ebff9dc10

~Therefore if "elem" is `Class` class, skip calling `=~` method.~
Therefore use case-when-else clause to avoid warning.