### PR TITLE
update ruby test version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,17 +1,13 @@
 language: ruby
-dist: trusty
-
+dist: bionic
 cache: bundler
 
 rvm:
-  - 1.9.3
-  - 2.0.0
-  - 2.1.10
-  - 2.2.6
-  - 2.3.3
+  - 2.5.7
+  - 2.6.5
+  - 2.7.1
   - ruby-head
-  - jruby-19mode
-  - rbx-3
+  - jruby
 
 sudo: false
 
@@ -22,9 +18,6 @@ env:
 matrix:
   allow_failures:
     - rvm: ruby-head
-    - rvm: rbx-3
   exclude:
-    - rvm: jruby-19mode
-      env: ESCAPE_UTILS=1
-    - rvm: rbx-3
+    - rvm: jruby
       env: ESCAPE_UTILS=1


### PR DESCRIPTION
Noticed that many of the ruby versions tested are past end of life

It looked like `ESCAPE_UTILS=1` was building native extensions, so I excluded that for jruby.
The previous travis.yml file was doing something similar.