### PR TITLE
Use Erubi instead of Erubis.

### DIFF
--- a/temple.gemspec
+++ b/temple.gemspec
@@ -25,5 +25,5 @@ Gem::Specification.new do |s|
   s.add_development_dependency('tilt')
   s.add_development_dependency('bacon')
   s.add_development_dependency('rake')
-  s.add_development_dependency('erubis')
+  s.add_development_dependency('erubi')
 end

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -20,8 +20,8 @@ module TestHelper
     Temple::ERB::Template.new(options) { src }.render
   end
 
-  def erubis(src, options = {})
-    Tilt::ErubisTemplate.new(options) { src }.render
+  def erubi(src, options = {})
+    Tilt::ErubiTemplate.new(options) { src }.render
   end
 end
 

--- a/test/test_erb.rb
+++ b/test/test_erb.rb
@@ -1,5 +1,5 @@
 require 'helper'
-require 'tilt/erubis'
+require 'tilt/erubi'
 
 describe Temple::ERB::Engine do
   it 'should compile erb' do
@@ -11,7 +11,7 @@ describe Temple::ERB::Engine do
 <% end %>
 }
 
-    erb(src).should.equal erubis(src)
+    erb(src).should.equal erubi(src)
   end
 
   it 'should recognize comments' do
@@ -20,7 +20,7 @@ hello
   <%# comment -- ignored -- useful in testing %>
 world}
 
-    erb(src).should.equal erubis(src)
+    erb(src).should.equal erubi(src)
   end
 
   it 'should recognize <%% and %%>' do
@@ -55,7 +55,7 @@ world}
 <% end %>
 }
 
-    erb(src, trim: true).should.equal erubis(src, trim: true)
-    erb(src, trim: false).should.equal erubis(src, trim: false)
+    erb(src, trim: true).should.equal erubi(src, trim: true)
+    erb(src, trim: false).should.equal erubi(src, trim: false)
   end
 end


### PR DESCRIPTION
Erubis is dead upstream for almost past 10 years, while Erubi is more lightweight alternative used by Ruby on Rails these days.

BTW I have submitted this PR, because I want to use it in my Fedora package, where it is burden to maintain Erubis without upstream response.