### PR TITLE
Add support for Rails' `annotate_rendered_view_with_filenames` option

### DIFF
--- a/lib/temple/templates/rails.rb
+++ b/lib/temple/templates/rails.rb
@@ -5,7 +5,15 @@ module Temple
 
       def call(template, source = nil)
         opts = {}.update(self.class.options).update(file: template.identifier)
-        self.class.compile((source || template.source), opts)
+        result = ''
+        if ActionView::Base.annotate_rendered_view_with_filenames && template.format == :html
+          result << "@output_buffer.safe_concat('<!-- BEGIN #{template.short_identifier} -->');"
+        end
+        result << self.class.compile((source || template.source), opts)
+        if ActionView::Base.annotate_rendered_view_with_filenames && template.format == :html
+          result << ";@output_buffer.safe_concat('<!-- END #{template.short_identifier} -->');@output_buffer"
+        end
+        result
       end
 
       def supports_streaming?


### PR DESCRIPTION
This is a raw first version that works. It's taken from https://translate.google.com/translate?sl=auto&tl=en&u=https://zenn.dev/kehra/articles/bbecaeb830032b which in turn adapts Rails' own code for Erb support.

I'm unfamiliar with Temple's code so I'd like some feedback and direction in case there's a better way to do this. Maybe a filter? Not sure. What would be the best way to add an automated test for this?

I've tested it in a real big Rails app using slim (which in turn uses temple) and it works perfectly.