### PR TITLE
Support annotate_rendered_view_with_filenames

### DIFF
--- a/lib/temple.rb
+++ b/lib/temple.rb
@@ -41,6 +41,7 @@ module Temple
   end
 
   module Filters
+    autoload :Ambles,             'temple/filters/ambles'
     autoload :CodeMerger,         'temple/filters/code_merger'
     autoload :ControlFlow,        'temple/filters/control_flow'
     autoload :MultiFlattener,     'temple/filters/multi_flattener'

--- a/lib/temple/filters/ambles.rb
+++ b/lib/temple/filters/ambles.rb
@@ -1,0 +1,21 @@
+module Temple
+  module Filters
+    class Ambles < Filter
+      define_options :preamble, :postamble
+
+      def initialize(*)
+        super
+        @preamble = options[:preamble]
+        @postamble = options[:postamble]
+      end
+
+      def call(ast)
+        ret = [:multi]
+        ret << [:static, @preamble] if @preamble
+        ret << ast
+        ret << [:static, @postamble] if @postamble
+        ret
+      end
+    end
+  end
+end

--- a/lib/temple/templates/rails.rb
+++ b/lib/temple/templates/rails.rb
@@ -5,6 +5,10 @@ module Temple
 
       def call(template, source = nil)
         opts = {}.update(self.class.options).update(file: template.identifier)
+        if ActionView::Base.try(:annotate_rendered_view_with_filenames) && template.format == :html
+          opts[:preamble] = "<!-- BEGIN #{template.short_identifier} -->\n"
+          opts[:postamble] = "<!-- END #{template.short_identifier} -->\n"
+        end
         self.class.compile((source || template.source), opts)
       end
 


### PR DESCRIPTION
An alternative patch for https://github.com/judofyr/temple/pull/133. Note that, with this patch, temple users need to `use :Ambles` in the engine to let `Temple::Templates::Rails` support the behavior.