### PR TITLE
Improve compatibility with upcoming Rails 7.1

### DIFF
--- a/lib/temple/generators/rails_output_buffer.rb
+++ b/lib/temple/generators/rails_output_buffer.rb
@@ -10,7 +10,7 @@ module Temple
     # @api public
     class RailsOutputBuffer < StringBuffer
       define_options :streaming,
-                     buffer_class: 'ActiveSupport::SafeBuffer',
+                     buffer_class: 'ActionView::OutputBuffer',
                      buffer: '@output_buffer',
                      # output_buffer is needed for Rails 3.1 Streaming support
                      capture_generator: RailsOutputBuffer
@@ -20,11 +20,7 @@ module Temple
       end
 
       def create_buffer
-        if options[:streaming] && options[:buffer] == '@output_buffer'
-          "#{buffer} = output_buffer || #{options[:buffer_class]}.new"
-        else
-          "#{buffer} = #{options[:buffer_class]}.new"
-        end
+        "#{buffer} = output_buffer || #{options[:buffer_class]}.new"
       end
 
       def concat(str)

--- a/test/test_generator.rb
+++ b/test/test_generator.rb
@@ -143,16 +143,16 @@ end
 describe Temple::Generators::RailsOutputBuffer do
   it 'should compile simple expressions' do
     gen = Temple::Generators::RailsOutputBuffer.new(freeze_static: false)
-    gen.call([:static,  'test']).should.equal '@output_buffer = ActiveSupport::SafeBuffer.new; ' +
+    gen.call([:static,  'test']).should.equal '@output_buffer = output_buffer || ActionView::OutputBuffer.new; ' +
       '@output_buffer.safe_concat(("test")); @output_buffer'
-    gen.call([:dynamic, 'test']).should.equal '@output_buffer = ActiveSupport::SafeBuffer.new; ' +
+    gen.call([:dynamic, 'test']).should.equal '@output_buffer = output_buffer || ActionView::OutputBuffer.new; ' +
       '@output_buffer.safe_concat(((test).to_s)); @output_buffer'
-    gen.call([:code,    'test']).should.equal '@output_buffer = ActiveSupport::SafeBuffer.new; ' +
+    gen.call([:code,    'test']).should.equal '@output_buffer = output_buffer || ActionView::OutputBuffer.new; ' +
       'test; @output_buffer'
   end
 
   it 'should freeze static' do
     gen = Temple::Generators::RailsOutputBuffer.new(freeze_static: true)
-    gen.call([:static,  'test']).should.equal '@output_buffer = ActiveSupport::SafeBuffer.new; @output_buffer.safe_concat(("test".freeze)); @output_buffer'
+    gen.call([:static,  'test']).should.equal '@output_buffer = output_buffer || ActionView::OutputBuffer.new; @output_buffer.safe_concat(("test".freeze)); @output_buffer'
   end
 end


### PR DESCRIPTION
In https://github.com/rails/rails/pull/45614 I modified `ActionView::OutputBuffer` to no longer be a subclass of `ActiveSupport::SafeBuffer` and as such it's not recommended to use `SafeBuffer` for buffering views anymore.

Additionally in https://github.com/rails/rails/pull/45731 I start doing some changes so that we stop mutating `@output_buffer`. So template should no longer assign `@output_buffer` themselves.