### PR TITLE
Fix a crash in StringSplitter filter

### DIFF
--- a/lib/temple/filters/string_splitter.rb
+++ b/lib/temple/filters/string_splitter.rb
@@ -25,28 +25,26 @@ module Temple
           private
 
           def strip_quotes!(tokens)
-            _, type, beg_str = tokens.shift
+            _, type, _beg_str = tokens.shift
             if type != :on_tstring_beg
               raise(FilterError, "Expected :on_tstring_beg but got: #{type}")
             end
 
-            _, type, end_str = tokens.pop
+            _, type, _end_str = tokens.pop
             if type != :on_tstring_end
               raise(FilterError, "Expected :on_tstring_end but got: #{type}")
             end
-
-            [beg_str, end_str]
           end
 
           def compile_tokens!(exps, tokens)
-            beg_str, end_str = strip_quotes!(tokens)
+            strip_quotes!(tokens)
 
             until tokens.empty?
               _, type, str = tokens.shift
 
               case type
               when :on_tstring_content
-                exps << [:static, eval("#{beg_str}#{str}#{end_str}").to_s]
+                exps << [:static, eval("%\0#{str}\0").to_s]
               when :on_embexpr_beg
                 embedded = shift_balanced_embexpr(tokens)
                 exps << [:dynamic, embedded] unless embedded.empty?

--- a/test/filters/test_string_splitter.rb
+++ b/test/filters/test_string_splitter.rb
@@ -10,9 +10,30 @@ if defined?(Ripper) && RUBY_VERSION >= "2.0.0"
       @filter = Temple::Filters::StringSplitter.new
     end
 
-    it 'should split :dynamic with string literal' do
-      @filter.call([:dynamic, '"static#{dynamic}"']
-      ).should.equal [:multi, [:static, 'static'], [:dynamic, 'dynamic']]
+    {
+      %q|''|                     => [:multi],
+      %q|""|                     => [:multi],
+      %q|"hello"|                => [:multi, [:static, 'hello']],
+      %q|"hello #{}world"|       => [:multi, [:static, 'hello '], [:static, 'world']],
+      %q|"#{hello}"|             => [:multi, [:dynamic, 'hello']],
+      %q|"nya#{123}"|            => [:multi, [:static, 'nya'], [:dynamic, '123']],
+      %q|"#{()}()"|              => [:multi, [:dynamic, '()'], [:static, '()']],
+      %q|" #{ " #{ '#{}' } " }"| => [:multi, [:static, ' '], [:multi, [:static, ' '], [:multi, [:static, '#{}']], [:static, ' ']]],
+      %q|%Q[a#{b}c#{d}e]|        => [:multi, [:static, 'a'], [:dynamic, 'b'], [:static, 'c'], [:dynamic, 'd'], [:static, 'e']],
+      %q|%q[a#{b}c#{d}e]|        => [:multi, [:static, 'a#{b}c#{d}e']],
+      %q|"\#{}#{123}"|           => [:multi, [:static, '#{}'], [:dynamic, '123']],
+      %q|"#{ '}' }"|             => [:multi, [:multi, [:static, '}']]],
+      %q| "a" # hello |          => [:multi, [:static, 'a']],
+      %q|"\""|                   => [:multi, [:static, '"']],
+      %q|"\\\\\\""|              => [:multi, [:static, '\\"']],
+      %q|'\"'|                   => [:multi, [:static, '\"']],
+      %q|'\\\"'|                 => [:multi, [:static, '\\"']],
+      %q|"static#{dynamic}"|     => [:multi, [:static, 'static'], [:dynamic, 'dynamic']],
+    }.each do |code, expected|
+      it "should split #{code}" do
+        actual = @filter.call([:dynamic, code])
+        actual.should.equal expected
+      end
     end
 
     describe '.compile' do

--- a/test/filters/test_string_splitter.rb
+++ b/test/filters/test_string_splitter.rb
@@ -20,6 +20,11 @@ if defined?(Ripper) && RUBY_VERSION >= "2.0.0"
         lambda { Temple::Filters::StringSplitter.compile('1') }.
           should.raise(Temple::FilterError)
       end
+
+      it 'should compile strings quoted with parenthesis' do
+        tokens = Temple::Filters::StringSplitter.compile('%Q(href("#{1 + 1}");)')
+        tokens.should.equal [[:static, "href(\""], [:dynamic, "1 + 1"], [:static, "\");"]]
+      end
     end
   end
 end


### PR DESCRIPTION
`StringSplitter` splits a string literal `%Q(href("#{1 + 1}");)` into `%Q(href()`, `1 + 1`, and `%Q();)`. 

Because `%Q(` `)` was used for quoting the string and the string content also has parenthesis, it results in `unterminated string meets end of file (SyntaxError)`.

To extract `"href("` safely, we should just use a null character for quoting a string to be `eval`ed.