### PR TITLE
Use same capture_generator across nested captures

### DIFF
--- a/lib/temple/generator.rb
+++ b/lib/temple/generator.rb
@@ -54,7 +54,7 @@ module Temple
     end
 
     def on_capture(name, exp)
-      capture_generator.new(buffer: name).call(exp)
+      capture_generator.new(**options, buffer: name).call(exp)
     end
 
     def on_static(text)

--- a/spec/generator_spec.rb
+++ b/spec/generator_spec.rb
@@ -62,6 +62,15 @@ describe Temple::Generator do
       'foo << (D:dynamic); C:code; foo; VAR << (S:after); VAR')
   end
 
+  it 'should compile nested capture with the same capture_generator' do
+    gen = SimpleGenerator.new(buffer: "VAR", capture_generator: SimpleGenerator)
+    expect(gen.call([:capture, "foo", [:multi,
+      [:capture, "bar", [:multi,
+        [:static, "a"],
+        [:static, "b"]]]]
+    ])).to eq "VAR = BUFFER; foo = BUFFER; bar = BUFFER; bar << (S:a); bar << (S:b); bar; foo; VAR"
+  end
+
   it 'should compile newlines' do
     gen = SimpleGenerator.new(buffer: "VAR")
     expect(gen.call([:multi,


### PR DESCRIPTION
Pass the configured captured_generator (along with all other top-level engine options) when initializing each capture_generator for handling `:capture` sexps. This ensures that nested captures behave consistently for the given top-level engine configuration.

This is the same diff from #112, but opened as a fresh PR over the current master branch.

See discussion in #112 for the various issues this fixes.