### PR TITLE
Make StaticAnalyzer recognize shorthand syntax as dynamic

### DIFF
--- a/lib/temple/static_analyzer.rb
+++ b/lib/temple/static_analyzer.rb
@@ -52,7 +52,8 @@ module Temple
             return false
           end
         end
-        true
+
+        !ShorthandSyntaxChecker.shorthand?(code)
       end
 
       def syntax_error?(code)
@@ -71,6 +72,29 @@ module Temple
 
         def on_parse_error(*)
           raise ParseError
+        end
+      end
+
+      class ShorthandSyntaxChecker < Ripper
+        class << self
+          def shorthand?(code)
+            instance = new(code)
+            instance.parse
+            instance.shorthand
+          end
+        end
+
+        attr_reader :shorthand
+
+        def initialize(*)
+          super
+          @shorthand = nil
+        end
+
+        private
+
+        def on_assoc_new(key, value)
+          @shorthand = true if value.nil?
         end
       end
     end

--- a/spec/static_analyzer_spec.rb
+++ b/spec/static_analyzer_spec.rb
@@ -10,13 +10,13 @@ describe Temple::StaticAnalyzer do
   if Temple::StaticAnalyzer.available?
     describe '.static?' do
       it 'should return true if given Ruby expression is static' do
-        ['true', 'false', '"hello world"', "[1, { 2 => 3 }]", "[\n1,\n]"].each do |exp|
+        ['true', 'false', '"hello world"', "[1, { 2 => 3 }]", "[\n1,\n]", '{a:1}'].each do |exp|
           expect(Temple::StaticAnalyzer.static?(exp)).to eq(true)
         end
       end
 
       it 'should return false if given Ruby expression is dynamic' do
-        ['1 + 2', 'variable', 'method_call(a)', 'CONSTANT'].each do |exp|
+        ['1 + 2', 'variable', 'method_call(a)', 'CONSTANT', '{a:}'].each do |exp|
           expect(Temple::StaticAnalyzer.static?(exp)).to eq(false)
         end
       end


### PR DESCRIPTION
There is a problem that `Temple::StaticAnalyzer.static?` does not handle the Hash shorthand syntax introduced in Ruby 3.1 well.

For example, this has caused the following problem on haml:

- https://github.com/haml/haml/issues/1138