### PR TITLE
Add a :compact option to strip whitespace off terminal nodes in pretty.rb

### DIFF
--- a/lib/temple/html/pretty.rb
+++ b/lib/temple/html/pretty.rb
@@ -10,7 +10,8 @@ module Temple
                                      header hgroup hr html li link meta nav ol option p
                                      rp rt ruby section script style table tbody td tfoot
                                      th thead tr ul video doctype).freeze,
-                     pre_tags: %w(code pre textarea).freeze
+                     pre_tags: %w(code pre textarea).freeze,
+                     compact: false
 
       def initialize(opts = {})
         super
@@ -61,6 +62,18 @@ module Temple
         @pretty = false
         result = [:multi, [:static, "#{tag_indent(name)}<#{name}"], compile(attrs)]
         result << [:static, (closed && @format != :html ? ' /' : '') + '>']
+
+        # strip newlines around terminal nodes
+        @pretty = true
+        case content
+        in [:multi, [:newline]]
+          return (result << [:static, "</#{name}>"])
+        in [:multi, [:multi, [:static, str]]]
+          return (result << [:static, "#{str}</#{name}>"])
+        in [:multi, [:escape, true, [:dynamic, code]], [:multi, [:newline]]]
+          return (result << [:multi, [:escape, true, [:dynamic, code]], [:static, "</#{name}>"]])
+        else nil
+        end
 
         @pretty = !@pre_tags || !options[:pre_tags].include?(name)
         if content

--- a/lib/temple/html/pretty.rb
+++ b/lib/temple/html/pretty.rb
@@ -73,7 +73,7 @@ module Temple
         in [:multi, [:escape, true, [:dynamic, code]], [:multi, [:newline]]]
           return (result << [:multi, [:escape, true, [:dynamic, code]], [:static, "</#{name}>"]])
         else nil
-        end
+        end if options[:compact]
 
         @pretty = !@pre_tags || !options[:pre_tags].include?(name)
         if content


### PR DESCRIPTION
I didn't see a way to do this, so I am submitting a PR to add the ability to strip whitespace off terminal nodes when pretty printing.

For example, instead of this:

```slim
foo Hello
bar World
baz
  bat Wow!
```

generating this:

```html
<foo>
  Hello
</foo>
<bar>
  World
</bar>
<baz>
  <bat>
    Wow!
  </bat>
</baz>
```

The `compact: true` option would generate:

```html
<foo>Hello</foo>
<bar>World</bar>
<baz>
  <bat>Wow!</bat>
</baz>
```
