### PR TITLE
Allow using prism as the parser engine

### DIFF
--- a/lib/temple/filters/static_analyzer.rb
+++ b/lib/temple/filters/static_analyzer.rb
@@ -4,7 +4,7 @@ module Temple
     # Convert [:dynamic, code] to [:static, text] if code is static Ruby expression.
     class StaticAnalyzer < Filter
       def call(exp)
-        # Optimize only when Ripper is available.
+        # Optimize only when a parser engine is available.
         if ::Temple::StaticAnalyzer.available?
           super
         else

--- a/lib/temple/filters/string_splitter.rb
+++ b/lib/temple/filters/string_splitter.rb
@@ -1,14 +1,70 @@
 # frozen_string_literal: true
-begin
-  require 'ripper'
-rescue LoadError
-end
+require 'temple/parser_engine'
 
 module Temple
   module Filters
     # Compile [:dynamic, "foo#{bar}"] to [:multi, [:static, 'foo'], [:dynamic, 'bar']]
     class StringSplitter < Filter
-      if defined?(Ripper) && Ripper.respond_to?(:lex)
+      if PARSER_ENGINE == :prism
+        class << self
+          # `code` param must be valid string literal
+          def compile(code)
+            compiled = try_compile(code)
+            raise(FilterError, "Expected string literal") unless compiled
+            compiled
+          end
+
+          def try_compile(code)
+            result = Prism.parse(code)
+            return unless result.success?
+
+            stmts = result.value.statements.body
+            return if stmts.size != 1
+
+            stack = [stmts.first]
+            compiled = []
+
+            until stack.empty?
+              case (node = stack.pop).type
+              when :interpolated_string_node
+                stack.concat(node.parts.reverse)
+              when :string_node
+                if !(unescaped = node.unescaped).empty?
+                  compiled << [:static, unescaped]
+                end
+              when :embedded_statements_node
+                if (stmts = node.statements) && !(slice = stmts.slice).empty?
+                  compiled << [:dynamic, slice]
+                end
+              when :embedded_variable_node
+                compiled << [:dynamic, node.variable.slice]
+              else
+                return
+              end
+            end
+
+            compiled
+          end
+        end
+
+        def on_dynamic(code)
+          return [:dynamic, code] if code.include?("\n")
+
+          compiled = StringSplitter.try_compile(code)
+          return [:dynamic, code] unless compiled
+
+          temple = [:multi]
+          compiled.each do |type, content|
+            case type
+            when :static
+              temple << [:static, content]
+            when :dynamic
+              temple << on_dynamic(content)
+            end
+          end
+          temple
+        end
+      elsif PARSER_ENGINE == :ripper
         class << self
           # `code` param must be valid string literal
           def compile(code)

--- a/lib/temple/parser_engine.rb
+++ b/lib/temple/parser_engine.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+module Temple
+  temple_parser_engine = ENV['TEMPLE_PARSER_ENGINE']
+
+  prism_available =
+    if !temple_parser_engine || temple_parser_engine == 'prism'
+      begin
+        require 'prism'
+        true
+      rescue LoadError
+      end
+    end
+
+  ripper_available =
+    if !temple_parser_engine || temple_parser_engine == 'ripper'
+      begin
+        require 'ripper'
+        Ripper.respond_to?(:lex)
+      rescue LoadError
+      end
+    end
+
+  PARSER_ENGINE =
+    if prism_available
+      :prism
+    elsif ripper_available
+      :ripper
+    else
+      :none
+    end
+
+  private_constant :PARSER_ENGINE
+end

--- a/lib/temple/static_analyzer.rb
+++ b/lib/temple/static_analyzer.rb
@@ -1,76 +1,122 @@
 # frozen_string_literal: true
-begin
-  require 'ripper'
-rescue LoadError
-end
+require 'temple/parser_engine'
 
 module Temple
   module StaticAnalyzer
-    STATIC_TOKENS = [
-      :on_tstring_beg, :on_tstring_end, :on_tstring_content,
-      :on_embexpr_beg, :on_embexpr_end,
-      :on_lbracket, :on_rbracket,
-      :on_qwords_beg, :on_words_sep, :on_qwords_sep,
-      :on_lparen, :on_rparen,
-      :on_lbrace, :on_rbrace, :on_label,
-      :on_int, :on_float, :on_imaginary,
-      :on_comma, :on_sp, :on_ignored_nl,
-    ].freeze
-
-    DYNAMIC_TOKENS = [
-      :on_ident, :on_period,
-    ].freeze
-
-    STATIC_KEYWORDS = [
-      'true', 'false', 'nil',
-    ].freeze
-
-    STATIC_OPERATORS = [
-      '=>',
-    ].freeze
-
-    class << self
-      def available?
-        defined?(Ripper) && Ripper.respond_to?(:lex)
-      end
-
-      def static?(code)
-        return false if code.nil? || code.strip.empty?
-        return false if syntax_error?(code)
-
-        Ripper.lex(code).each do |_, token, str|
-          case token
-          when *STATIC_TOKENS
-            # noop
-          when :on_kw
-            return false unless STATIC_KEYWORDS.include?(str)
-          when :on_op
-            return false unless STATIC_OPERATORS.include?(str)
-          when *DYNAMIC_TOKENS
-            return false
-          else
-            return false
-          end
+    if PARSER_ENGINE == :prism
+      class << self
+        def available?
+          true
         end
-        true
-      end
 
-      def syntax_error?(code)
-        SyntaxChecker.new(code).parse
-        false
-      rescue SyntaxChecker::ParseError
-        true
-      end
-    end
+        def static?(code)
+          return false if code.nil? || code.strip.empty?
+          (result = Prism.parse(code)).success? && static_node?(result.value)
+        end
 
-    if defined?(Ripper)
-      class SyntaxChecker < Ripper
-        class ParseError < StandardError; end
+        def syntax_error?(code)
+          !Prism.parse_success?(code)
+        end
 
         private
 
-        def on_parse_error(*)
-          raise ParseError
+        def static_node?(node)
+          case node.type
+          when :program_node
+            static_node?(node.statements)
+          when :parentheses_node
+            (stmts = node.body).is_a?(Prism::StatementsNode) &&
+              static_node?(stmts)
+          when :statements_node
+            node.body.size == 1 && static_node?(node.body.first)
+          when :interpolated_string_node
+            node.parts.all? { |part| static_node?(part) }
+          when :embedded_statements_node
+            (stmts = node.statements) && static_node?(stmts)
+          when :array_node
+            node.elements.all? { |elem| static_node?(elem) }
+          when :hash_node, :keyword_hash_node
+            node.elements.all? { |elem| static_node?(elem) }
+          when :assoc_node
+            static_node?(node.key) && static_node?(node.value)
+          when :string_node, :integer_node, :float_node, :imaginary_node,
+               :rational_node, :symbol_node, :true_node, :false_node, :nil_node
+            true
+          else
+            false
+          end
+        end
+      end
+    elsif PARSER_ENGINE == :ripper
+      STATIC_TOKENS = [
+        :on_tstring_beg, :on_tstring_end, :on_tstring_content,
+        :on_embexpr_beg, :on_embexpr_end,
+        :on_lbracket, :on_rbracket,
+        :on_qwords_beg, :on_words_sep, :on_qwords_sep,
+        :on_lparen, :on_rparen,
+        :on_lbrace, :on_rbrace, :on_label,
+        :on_int, :on_float, :on_imaginary,
+        :on_comma, :on_sp, :on_ignored_nl,
+      ].freeze
+
+      DYNAMIC_TOKENS = [
+        :on_ident, :on_period,
+      ].freeze
+
+      STATIC_KEYWORDS = [
+        'true', 'false', 'nil',
+      ].freeze
+
+      STATIC_OPERATORS = [
+        '=>',
+      ].freeze
+
+      class << self
+        def available?
+          true
+        end
+
+        def static?(code)
+          return false if code.nil? || code.strip.empty? || syntax_error?(code)
+
+          Ripper.lex(code).each do |_, token, str|
+            case token
+            when *STATIC_TOKENS
+              # noop
+            when :on_kw
+              return false unless STATIC_KEYWORDS.include?(str)
+            when :on_op
+              return false unless STATIC_OPERATORS.include?(str)
+            when *DYNAMIC_TOKENS
+              return false
+            else
+              return false
+            end
+          end
+          true
+        end
+
+        def syntax_error?(code)
+          SyntaxChecker.new(code).parse
+          false
+        rescue SyntaxChecker::ParseError
+          true
+        end
+
+        class SyntaxChecker < Ripper
+          class ParseError < StandardError; end
+
+          private
+
+          def on_parse_error(*)
+            raise ParseError
+          end
+        end
+      end
+    else
+      class << self
+        def available?
+          false
         end
       end
     end

--- a/spec/filters/string_splitter_spec.rb
+++ b/spec/filters/string_splitter_spec.rb
@@ -1,10 +1,6 @@
 require 'spec_helper'
-begin
-  require 'ripper'
-rescue LoadError
-end
 
-if defined?(Ripper)
+if Temple::StaticAnalyzer.available?
   describe Temple::Filters::StringSplitter do
     before do
       @filter = Temple::Filters::StringSplitter.new

--- a/spec/static_analyzer_spec.rb
+++ b/spec/static_analyzer_spec.rb
@@ -3,7 +3,7 @@ require 'spec_helper'
 describe Temple::StaticAnalyzer do
   describe '.available?' do
     it 'should return true if its dependency is available' do
-      expect(Temple::StaticAnalyzer.available?).to eq(defined?(Ripper) && Ripper.respond_to?(:lex))
+      expect(Temple::StaticAnalyzer.available?).to eq(!!(defined?(Prism) || (defined?(Ripper) && Ripper.respond_to?(:lex))))
     end
   end
 


### PR DESCRIPTION
Allow consumers to use prism as the parser engine, and set it to the default if it is available to be required.

Prism ends up being quite a bit faster here, and there are a couple of nice correctness things (rationals like 1r are considered static now, for example).

I wrote a benchmark, the script is here:

<details>
<summary>
benchmark.rb
</summary>

```ruby
# frozen_string_literal: true

# Run benchmarks for both engines by spawning subprocesses:
#   ruby benchmark.rb
#
# Run a single engine directly:
#   TEMPLE_PARSER_ENGINE=prism ruby benchmark.rb
#   TEMPLE_PARSER_ENGINE=ripper ruby benchmark.rb

if !ENV.key?("TEMPLE_PARSER_ENGINE")
  require "tempfile"

  results = {}
  %w[prism ripper].each do |engine|
    file = Tempfile.new(["benchmark_#{engine}_", ".txt"])
    file.close
    system({ "TEMPLE_PARSER_ENGINE" => engine }, RbConfig.ruby, __FILE__, out: file.path)
    results[engine] = File.read(file.path)
    file.unlink
  end

  results.each do |engine, output|
    puts "=" * 60
    puts "  #{engine.upcase}"
    puts "=" * 60
    puts output
    puts
  end

  exit
end

$LOAD_PATH.unshift(File.join(__dir__, "lib"))
require "benchmark/ips"
require "temple"
require "temple/static_analyzer"
require "temple/filters/string_splitter"
require "temple/filters/static_analyzer"

engine = ENV.fetch("TEMPLE_PARSER_ENGINE") { defined?(Prism) ? "prism" : "ripper" }
puts "Engine: #{engine}"
puts

static_expressions = ['true', 'false', '"hello world"', '[1, { 2 => 3 }]', "[\n1,\n]"]
dynamic_expressions = ['1 + 2', 'variable', 'method_call(a)', 'CONSTANT']
valid_code = ['Foo.bar.baz { |c| c.d! }', '{ foo: bar }']
invalid_code = ['Foo.bar.baz { |c| c.d! ', ' foo: bar ']
string_literals = ['"hello"', '"static#{dynamic}"', '%Q[a#{b}c#{d}e]', '"hello #{}world"', '"\#{}#{123}"', '%Q(href("#{1 + 1}");)']
filter_inputs = string_literals.map { |code| [:dynamic, code] }
analyzer_inputs = [[:dynamic, '"#{"hello"}#{100}"'], [:dynamic, '"#{hello}#{100}"'], [:dynamic, "[100,\n200,\n]"], [:dynamic, 'true'], [:dynamic, 'variable']]

Benchmark.ips do |x|
  x.report("StaticAnalyzer.static? static")  { static_expressions.each { |c| Temple::StaticAnalyzer.static?(c) } }
  x.report("StaticAnalyzer.static? dynamic") { dynamic_expressions.each { |c| Temple::StaticAnalyzer.static?(c) } }
  x.report("syntax_error? valid")            { valid_code.each { |c| Temple::StaticAnalyzer.syntax_error?(c) } }
  x.report("syntax_error? invalid")          { invalid_code.each { |c| Temple::StaticAnalyzer.syntax_error?(c) } }
  x.report("StringSplitter.compile")         { string_literals.each { |c| Temple::Filters::StringSplitter.compile(c) } }
  x.report("StringSplitter filter") do
    filter = Temple::Filters::StringSplitter.new
    filter_inputs.each { |exp| filter.call(exp) }
  end
  x.report("StaticAnalyzer filter") do
    filter = Temple::Filters::StaticAnalyzer.new
    analyzer_inputs.each { |exp| filter.call(exp) }
  end
end

```
</details>

On my machine it ends up being quite a bit faster.

<details>
<summary>
Results
</summary>

```
============================================================
  PRISM
============================================================
Engine: prism

ruby 4.1.0dev (2026-02-16T15:49:22Z master 38c602ea00) +PRISM [arm64-darwin23]
Warming up --------------------------------------
StaticAnalyzer.static? static
                         5.120k i/100ms
StaticAnalyzer.static? dynamic
                         6.338k i/100ms
 syntax_error? valid    65.753k i/100ms
syntax_error? invalid
                        50.021k i/100ms
StringSplitter.compile
                         2.382k i/100ms
StringSplitter filter
                         1.459k i/100ms
StaticAnalyzer filter
                         2.458k i/100ms
Calculating -------------------------------------
StaticAnalyzer.static? static
                         51.339k (± 3.5%) i/s   (19.48 μs/i) -    261.120k in   5.093414s
StaticAnalyzer.static? dynamic
                         61.660k (± 4.4%) i/s   (16.22 μs/i) -    310.562k in   5.047246s
 syntax_error? valid    662.991k (± 3.5%) i/s    (1.51 μs/i) -      3.353M in   5.065338s
syntax_error? invalid
                        504.193k (± 3.2%) i/s    (1.98 μs/i) -      2.551M in   5.065447s
StringSplitter.compile
                         23.359k (± 3.5%) i/s   (42.81 μs/i) -    119.100k in   5.105032s
StringSplitter filter
                         14.715k (± 2.4%) i/s   (67.96 μs/i) -     74.409k in   5.059881s
StaticAnalyzer filter
                         24.566k (± 1.8%) i/s   (40.71 μs/i) -    125.358k in   5.104575s

============================================================
  RIPPER
============================================================
Engine: ripper

ruby 4.1.0dev (2026-02-16T15:49:22Z master 38c602ea00) +PRISM [arm64-darwin23]
Warming up --------------------------------------
StaticAnalyzer.static? static
                         1.060k i/100ms
StaticAnalyzer.static? dynamic
                         2.126k i/100ms
 syntax_error? valid     9.598k i/100ms
syntax_error? invalid
                         9.273k i/100ms
StringSplitter.compile
                       652.000 i/100ms
StringSplitter filter
                       378.000 i/100ms
StaticAnalyzer filter
                       695.000 i/100ms
Calculating -------------------------------------
StaticAnalyzer.static? static
                         11.190k (± 4.0%) i/s   (89.36 μs/i) -     56.180k in   5.030278s
StaticAnalyzer.static? dynamic
                         20.688k (± 2.9%) i/s   (48.34 μs/i) -    104.174k in   5.039785s
 syntax_error? valid     91.207k (± 8.7%) i/s   (10.96 μs/i) -    451.106k in   5.004029s
syntax_error? invalid
                         87.513k (± 7.1%) i/s   (11.43 μs/i) -    435.831k in   5.010403s
StringSplitter.compile
                          6.163k (± 9.5%) i/s  (162.27 μs/i) -     30.644k in   5.042302s
StringSplitter filter
                          3.534k (± 9.5%) i/s  (282.99 μs/i) -     17.766k in   5.083927s
StaticAnalyzer filter
                          8.389k (± 4.5%) i/s  (119.20 μs/i) -     42.395k in   5.065375s
```
</details>