### PR TITLE
Replace `=~` with `.match?` where possible

### DIFF
--- a/lib/temple/filters/code_merger.rb
+++ b/lib/temple/filters/code_merger.rb
@@ -10,7 +10,7 @@ module Temple
         exps.each do |exp|
           if exp.first == :code
             if code
-              code << '; ' unless code =~ /\n\Z/
+              code << '; ' unless /\n\Z/.match?(code)
               code << exp.last
             else
               code = exp.last.dup

--- a/lib/temple/filters/remove_bom.rb
+++ b/lib/temple/filters/remove_bom.rb
@@ -6,7 +6,7 @@ module Temple
     # @api public
     class RemoveBOM < Parser
       def call(s)
-        return s if s.encoding.name !~ /^UTF-(8|16|32)(BE|LE)?/
+        return s unless /^UTF-(8|16|32)(BE|LE)?/.match?(s.encoding.name)
         s.gsub(Regexp.new("\\A\uFEFF".encode(s.encoding.name)), ''.freeze)
       end
     end

--- a/lib/temple/html/pretty.rb
+++ b/lib/temple/html/pretty.rb
@@ -26,7 +26,7 @@ module Temple
 
       def on_static(content)
         return [:static, content] unless @pretty
-        unless @pre_tags && @pre_tags =~ content
+        unless @pre_tags && @pre_tags.match?(content)
           content = content.sub(/\A\s*\n?/, "\n".freeze) if @indent_next
           content = content.gsub("\n".freeze, indent)
         end

--- a/lib/temple/utils.rb
+++ b/lib/temple/utils.rb
@@ -77,7 +77,7 @@ module Temple
     def indent_dynamic(text, indent_next, indent, pre_tags = nil)
       text = text.to_s
       safe = text.respond_to?(:html_safe?) && text.html_safe?
-      return text if pre_tags && text =~ pre_tags
+      return text if pre_tags && pre_tags.match?(text)
 
       level = text.scan(/^\s*/).map(&:size).min
       text = text.gsub(/(?!\A)^\s{#{level}}/, '') if level > 0


### PR DESCRIPTION
This commit updates temple filters to consistently use Ruby's `Regexp#match?` instead of the `=~` operator for regular expression matching.

`match?` is more idiomatic for predicate checks and does not require setting the global match variables, improving performance and code clarity.

No functional changes to parsing logic are intended with this refactor.

Two offenses automatically fixed via

```
rubocop --only Performance/RegexpMatch -a
```

plus a fix of Style/NegatedIf for clarity

---

> [!NOTE]
> This PR is human generated, changes are automatic (RuboCop). Ref: haml/haml#1196
> The following report is AI-generated (Sol 5.6)

## Summary

This change replaces four `=~`/`!~` checks with `Regexp#match?` where Temple
only needs a boolean result. It is a small, non-breaking cleanup:

- `match?` states the predicate intent directly.
- It does not update Ruby's regular-expression backreferences.
- It avoids creating or exposing `MatchData` that Temple never reads.
- The affected methods return the same values and generate the same output.

This is low-hanging fruit, not a major Temple performance improvement. The
benchmarks show useful local gains in matching paths, but most of these regex
checks are either uncommon or a small part of a larger filter operation.

**No meaningful end-to-end rendering improvement is claimed.**

## Changed call sites

| File | Use |
|---|---|
| `lib/temple/filters/code_merger.rb` | Check whether merged code ends in a newline |
| `lib/temple/filters/remove_bom.rb` | Check whether the input has a UTF encoding |
| `lib/temple/html/pretty.rb` | Detect preformatted static content |
| `lib/temple/utils.rb` | Detect preformatted dynamic content at runtime |

`match?` is appropriate because none of these methods reads `$~`, `$1`,
`Regexp.last_match`, or any other backreference produced by `=~`.

## Benchmark method

**Source code:** https://gist.github.com/tagliala/3368450ed980b9216e4e52d1d9e7db9c

`bench_match_predicate.rb` contains the previous and current implementations
of the four affected methods. It compares them using the same Temple objects
and representative inputs:

- `CodeMerger#on_multi` processes a control-flow AST containing code and
  newline nodes.
- `Pretty#compile` processes an HTML page containing raw preformatted static
  output and normal abstract HTML nodes.
- `Utils.indent_dynamic` processes both preformatted output and ordinary
  multiline output.
- `RemoveBOM#call` processes a UTF-8 template beginning with a BOM.

The script verifies that the previous and current implementations produce the
same result before measuring them. Throughput uses `benchmark-ips`; allocation
counts come directly from `GC.stat(:total_allocated_objects)` with GC disabled
during each sample. Filter construction is outside the measured operations.

The comparison was run without a JIT on Apple Silicon using:

- Ruby 3.2.9
- Ruby 3.3.12
- Ruby 3.4.10
- Ruby 4.0.6

Each cross-version throughput sample used a one-second warmup and a two-second
measurement. The allocation sample used 500 calls.

## Throughput results

The table reports the throughput ratio of the current `match?` implementation
over the previous `=~` implementation. "Same" means the difference fell
within benchmark error.

| Real method and input | Ruby 3.2.9 | Ruby 3.3.12 | Ruby 3.4.10 | Ruby 4.0.6 |
|---|---:|---:|---:|---:|
| `CodeMerger`, control-flow AST | 1.50x | 1.37x | 1.54x | 1.34x |
| `Pretty`, page with static `<pre>` output | 1.01x | Same | 1.03x | Same |
| `indent_dynamic`, preformatted output | 1.80x | 1.46x | 1.69x | 1.51x |
| `indent_dynamic`, ordinary multiline output | Same | Same | Same | Same |
| `RemoveBOM`, UTF-8 template | 1.10x | 1.10x | 1.13x | 1.09x |

The useful hot paths are therefore narrow:

- `CodeMerger` benefits when newline nodes cause repeated successful matches
  while merging code.
- `indent_dynamic` benefits when dynamic output contains `<code>`, `<pre>`, or
  `<textarea>` and returns early.
- The more common non-matching multiline indentation path shows no measurable
  improvement because scanning and rewriting the text dominate the method.
- The complete Pretty traversal shows no reliable throughput change because
  tree traversal and output construction dominate one predicate call.
- `RemoveBOM` improves locally, but it runs only once per parsed input.

## Allocation results

These are total Ruby objects allocated per complete method/filter call, not
allocations for an isolated regex expression.

| Real method and input | Ruby 3.2.9 | Ruby 3.3.12 | Ruby 3.4.10 | Ruby 4.0.6 |
|---|---:|---:|---:|---:|
| `CodeMerger`, previous/current | 14 / 5 | 14 / 5 | 14 / 5 | 11 / 5 |
| `Pretty`, previous/current | 95 / 93 | 95 / 93 | 95 / 93 | 95 / 93 |
| `indent_dynamic` preformatted, previous/current | 2 / 0 | 2 / 0 | 2 / 0 | 2 / 0 |
| `indent_dynamic` multiline, previous/current | 16 / 16 | 16 / 16 | 16 / 16 | 13 / 13 |
| `RemoveBOM`, previous/current | 8 / 7 | 8 / 7 | 8 / 7 | 6 / 6 |

The allocations saved are real but small in absolute terms. For example, the
Pretty traversal still allocates 93 objects; changing the predicate saves only
two objects.

## Ruby 4.0 note

Ruby 4.0 does not remove the documented backreference side effects of `=~`.
It does, however, include a CRuby interpreter optimization that can reuse an
unexposed backreference `MatchData` object while it is not marked busy. This is
guarded object reuse, not ZJIT escape analysis, and `$~` remains correct when
observed.

That optimization explains why a tight Ruby 4.0 loop can report almost no new
objects per `=~` call after the first match. It does not make `=~` equivalent to
`match?`, and the real Temple method measurements above still show allocation
savings in three of the four tested call sites on Ruby 4.0.6.

Relevant CRuby references:

- [ruby/ruby#12801](https://github.com/ruby/ruby/pull/12801)
- [Commit 97e6ad4: reuse a backreference when it is not busy](https://github.com/ruby/ruby/commit/97e6ad49a4604e7e4ca04da2aaafc63cbd5d29d8)
- [Ruby issue #20652](https://bugs.ruby-lang.org/issues/20652)

The practical conclusion is unchanged: `match?` is the reliable and idiomatic
choice when match data is not needed. The Ruby 4.0 optimization only reduces
some of the allocation penalty of `=~`; it does not provide a reason to retain
the side-effecting predicate.

## Reproduce

Run the full benchmark on one installed Ruby:

```sh
MISE_RUBY_VERSION=3.3.12 mise exec -- ruby bench_match_predicate.rb
```

Run the shorter configuration used for the cross-version comparison:

```sh
BENCHMARK_TIME=2 \
BENCHMARK_WARMUP=1 \
ALLOCATION_ITERATIONS=500 \
MISE_RUBY_VERSION=4.0.6 \
mise exec -- ruby bench_match_predicate.rb
```

The script uses `bundler/inline` to install `benchmark-ips` when necessary.
