### PR TITLE
Isolate thread options by class identity

### DIFF
--- a/lib/temple/mixins/options.rb
+++ b/lib/temple/mixins/options.rb
@@ -63,7 +63,7 @@ module Temple
       protected
 
       def thread_options_key
-        @thread_options_key ||= "#{self.name}-thread-options".to_sym
+        @thread_options_key ||= "#{self.name}-#{object_id}-thread-options".to_sym
       end
     end
 


### PR DESCRIPTION
## Summary
Scope temporary options to the class object, not just its name. Anonymous classes currently share one thread-local key; reloaded classes can also reuse an old class name.

## Reproduction
Using Temple 0.10.7 (master `3994e0374df17cccdc56274b5dfbc865ccf9b733` before the fix):

```ruby
require 'temple'
a = Class.new(Temple::Filter)
b = Class.new(Temple::Filter)
a.define_options(x: :a)
b.define_options(x: :b)
p a.with_options(x: :temporary) { [a.new.options[:x], b.new.options[:x]] }
# Before: [:temporary, :temporary]; after: [:temporary, :b]
```

## Verification
- Unmodified `rake spec`: 162 examples, zero failures on Ruby 3.2.11 and 4.0.6, each with Prism and Ripper.
- 600 focused checks per Ruby/parser combination: class isolation, nesting, exception cleanup and separate threads.
- All 51 runtime files compile on both Rubies. No test files changed; focused verification ran outside the repository.

## Breaking changes / limitations
No public API change intended. Classes no longer inherit accidental temporary overrides from unrelated classes with the same/absent name.
Ruby 2.5–3.1, JRuby and TruffleRuby were not locally exercised; the upstream matrix remains necessary.
