### PR TITLE
Preserve caller-owned source string encoding

### DIFF
--- a/lib/temple/filters/encoding.rb
+++ b/lib/temple/filters/encoding.rb
@@ -10,7 +10,7 @@ module Temple
       def call(s)
         if options[:encoding] && s.respond_to?(:encoding)
           old_enc = s.encoding
-          s = +s
+          s = s.dup
           s.force_encoding(options[:encoding])
           # Fall back to old encoding if new encoding is invalid
           unless s.valid_encoding?


### PR DESCRIPTION
## Summary
Duplicate source strings before changing their encoding. Temple documents that compilers must not mutate their inputs; unary plus returns mutable strings unchanged. The existing encoding fallback is retained.

## Reproduction
Using Temple 0.10.7 (master `3994e0374df17cccdc56274b5dfbc865ccf9b733` before the fix):

```ruby
require 'temple'
source = 'hello'.encode(Encoding::ISO_8859_1)
output = Temple::Filters::Encoding.new.call(source)
p [source.encoding.name, output.encoding.name]
# Before: ["UTF-8", "UTF-8"]; after: ["ISO-8859-1", "UTF-8"]
```

## Verification
- Unmodified `rake spec`: 162 examples, zero failures on Ruby 3.2.11 and 4.0.6, each with Prism and Ripper.
- 480 focused checks per Ruby/parser combination: frozen/mutable inputs, valid/invalid byte sequences, four encodings and disabled conversion.
- All 51 runtime files compile on both Rubies. No test files changed; focused verification ran outside the repository.

## Breaking changes / limitations
No output-encoding change intended. Mutable inputs now remain unchanged and returned strings need not have the same identity. This retains the chilled-string fix discussed in #151; it does not claim to fix the separate JRuby report #155.
Ruby 2.5–3.1, JRuby and TruffleRuby were not locally exercised; the upstream matrix remains necessary.
