### PR TITLE
Preserve caller-owned template option hashes

### DIFF
--- a/lib/temple/mixins/template.rb
+++ b/lib/temple/mixins/template.rb
@@ -6,6 +6,7 @@ module Temple
       include ClassOptions
 
       def compile(code, options)
+        options = options.dup
         engine = options.delete(:engine)
         raise 'No engine configured' unless engine
         engine.new(options).call(code)
@@ -16,6 +17,7 @@ module Temple
       end
 
       def create(engine, options)
+        options = options.dup
         register_as = options.delete(:register_as)
         template = Class.new(self)
         template.disable_option_validator!


### PR DESCRIPTION
## Summary
Copy template option hashes before consuming engine/register_as keys. Reusing compile options currently fails after the first call, and frozen option hashes raise FrozenError.

## Reproduction
Using Temple 0.10.7 (master `3994e0374df17cccdc56274b5dfbc865ccf9b733` before the fix):

```ruby
require 'temple'
options = {engine: Temple::ERB::Engine}.freeze
2.times { p Temple::Templates::Tilt.compile('hello', options) }
# Before: FrozenError; after: two successful compilations.
Temple::Templates::Tilt.create(Temple::ERB::Engine, {register_as: nil}.freeze)
```

## Verification
- Unmodified `rake spec`: 162 examples, zero failures on Ruby 3.2.11 and 4.0.6, each with Prism and Ripper.
- 1,000 focused checks per Ruby/parser combination: repeated compilation, frozen and mutable options, generated Tilt template rendering and caller ownership.
- All 51 runtime files compile on both Rubies. No test files changed; focused verification ran outside the repository.

## Breaking changes / limitations
No output/API break intended. Caller hashes retain their keys rather than being consumed. The copy is shallow because only top-level keys are changed.
Ruby 2.5–3.1, JRuby and TruffleRuby were not locally exercised; the upstream matrix remains necessary.
