### PR TITLE
Return an enumerator from ImmutableMap each

### DIFF
--- a/lib/temple/map.rb
+++ b/lib/temple/map.rb
@@ -19,6 +19,7 @@ module Temple
     end
 
     def each
+      return enum_for(:each) unless block_given?
       keys.each {|k| yield(k, self[k]) }
     end
 


### PR DESCRIPTION
## Summary
Return an Enumerator when ImmutableMap#each is called without a block, as expected for an Enumerable collection. Existing block iteration and layered-key precedence are unchanged.

## Reproduction
Using Temple 0.10.7 (master `3994e0374df17cccdc56274b5dfbc865ccf9b733` before the fix):

```ruby
require 'temple'
map = Temple::ImmutableMap.new({a: 1}, {a: 2, b: 3})
p map.each.to_a
# Before: LocalJumpError; after: [[:a, 1], [:b, 3]]
```

## Verification
- Unmodified `rake spec`: 162 examples, zero failures on Ruby 3.2.11 and 4.0.6, each with Prism and Ripper.
- 1,200 focused checks per Ruby/parser combination: generated layered maps, duplicate keys, empty maps, existing Enumerable behavior and bounded enumeration.
- All 51 runtime files compile on both Rubies. No test files changed; focused verification ran outside the repository.

## Breaking changes / limitations
No breaking change intended. Block-less each now returns an Enumerator; existing block return behavior is preserved.
Ruby 2.5–3.1, JRuby and TruffleRuby were not locally exercised; the upstream matrix remains necessary.
