### PR TITLE
Reset pretty rendering state for each compilation

### DIFF
--- a/lib/temple/html/pretty.rb
+++ b/lib/temple/html/pretty.rb
@@ -21,6 +21,9 @@ module Temple
       end
 
       def call(exp)
+        @indent_next = nil
+        @indent = 0
+        @pretty = options[:pretty]
         @pretty ? [:multi, preamble, compile(exp)] : super
       end
 


### PR DESCRIPTION
## Summary
Reset per-compilation pretty-print state when a filter is reused. Temple explicitly permits repeated calls on one compiler instance; the previous render otherwise leaves a leading newline in the next render.

## Reproduction
Using Temple 0.10.7 (master `3994e0374df17cccdc56274b5dfbc865ccf9b733` before the fix):

```ruby
require 'temple'
require 'slim'
engine = Slim::Engine.new(pretty: true)
p [eval(engine.call('p hello')), eval(engine.call('p hello'))]
# Before: the second output has an extra leading newline.
# After: both outputs are "<p>\n  hello\n</p>".
```

## Verification
- Unmodified `rake spec`: 162 examples, zero failures on Ruby 3.2.11 and 4.0.6, each with Prism and Ripper.
- 1,080 focused checks per Ruby/parser combination: repeated Slim engine calls versus fresh engines, HTML/XHTML/XML, indentation options and preformatted content.
- All 51 runtime files compile on both Rubies. No test files changed; focused verification ran outside the repository.

## Breaking changes / limitations
No API break intended. Repeated compiles now produce the same output as fresh instances; accidental leading whitespace disappears. Concurrent use of one compiler remains unsupported. Separate compact-output feature #150 is unchanged.
Ruby 2.5–3.1, JRuby and TruffleRuby were not locally exercised; the upstream matrix remains necessary.
