### PR TITLE
Preserve escaped newline literals during dynamic merging

### DIFF
--- a/lib/temple/filters/dynamic_merger.rb
+++ b/lib/temple/filters/dynamic_merger.rb
@@ -41,7 +41,7 @@ module Temple
         exps.each do |type, arg|
           case type
           when :static
-            strlit_body << arg.dump.sub!(/\A"/, '').sub!(/"\z/, '').gsub('\n', "\n")
+            strlit_body << arg.dump.sub!(/\A"/, '').sub!(/"\z/, '').gsub(/\\\\|\\n/) { |escape| escape == '\n' ? "\n" : escape }
           when :dynamic
             strlit_body << "\#{#{arg}}"
           when :newline


### PR DESCRIPTION
## Summary
Preserve literal backslash-n sequences while converting dumped newline escapes back to real source newlines. Consuming escaped backslashes as pairs prevents a literal \n from becoming a Ruby line continuation and disappearing from rendered output.

## Reproduction
Using Temple 0.10.7 (master `3994e0374df17cccdc56274b5dfbc865ccf9b733` before the fix):

```ruby
require 'temple'
literal = "\\n"
exp = [:multi, [:static, literal], [:dynamic, '42']]
merged = Temple::Filters::DynamicMerger.new.call(exp)
p eval(Temple::Generators::StringBuffer.new.call(merged))
# Before: "42"; after: "\\n42"
```

## Verification
- Unmodified `rake spec`: 162 examples, zero failures on Ruby 3.2.11 and 4.0.6, each with Prism and Ripper.
- 3,600 focused checks per Ruby/parser combination: 1,800 seeded string roundtrips and source-newline count comparisons, including backslashes, quotes, interpolation markers, NUL and Unicode.
- All 51 runtime files compile on both Rubies. No test files changed; focused verification ran outside the repository.

## Breaking changes / limitations
No API break intended. Literal text that was previously corrupted is preserved. Actual newline/source-line handling is retained; broader non-UTF-8 encoding behavior is outside this fix.
Ruby 2.5–3.1, JRuby and TruffleRuby were not locally exercised; the upstream matrix remains necessary.
