### PR TITLE
Compile Ripper shorthand variable interpolation

### DIFF
--- a/lib/temple/filters/string_splitter.rb
+++ b/lib/temple/filters/string_splitter.rb
@@ -105,6 +105,8 @@ module Temple
               when :on_tstring_content
                 beg_str, end_str = escape_quotes(beg_str, end_str)
                 exps << [:static, eval("#{beg_str}#{str}#{end_str}").to_s]
+              when :on_embvar
+                exps << [:dynamic, tokens.shift[2]]
               when :on_embexpr_beg
                 embedded = shift_balanced_embexpr(tokens)
                 exps << [:dynamic, embedded] unless embedded.empty?


### PR DESCRIPTION
## Summary
Handle Ripper on_embvar tokens so instance/global/class variable shorthand interpolation is retained when splitting string literals. The Prism path is unchanged.

## Reproduction
Using Temple 0.10.7 (master `3994e0374df17cccdc56274b5dfbc865ccf9b733` before the fix):

```ruby
require 'temple'
@value = 'hello'
exp = Temple::Filters::StringSplitter.new.call([:dynamic, '"#@value"'])
p eval(Temple::Generators::StringBuffer.new.call(exp))
# With TEMPLE_PARSER_ENGINE=ripper: before ""; after "hello".
```

## Verification
- Unmodified `rake spec`: 162 examples, zero failures on Ruby 3.2.11 and 4.0.6, each with Prism and Ripper.
- 600 focused checks per Ruby/parser combination: instance/global/missing values, escaped markers, mixed ordinary interpolation and percent-quoted strings.
- All 51 runtime files compile on both Rubies. No test files changed; focused verification ran outside the repository.

## Breaking changes / limitations
No API break intended. Ruby shorthand interpolation now has the same output under Ripper and Prism. No parser dependency change.
Ruby 2.5–3.1, JRuby and TruffleRuby were not locally exercised; the upstream matrix remains necessary.
