### PR TITLE
Preserve paired delimiter escapes when splitting strings

### DIFF
--- a/lib/temple/filters/string_splitter.rb
+++ b/lib/temple/filters/string_splitter.rb
@@ -103,8 +103,12 @@ module Temple
 
               case type
               when :on_tstring_content
-                beg_str, end_str = escape_quotes(beg_str, end_str)
-                exps << [:static, eval("#{beg_str}#{str}#{end_str}").to_s]
+                quote_start, quote_end = escape_quotes(beg_str, end_str)
+                if quote_start != beg_str
+                  delimiters = Regexp.union('\\', beg_str[-1], end_str)
+                  str = str.gsub(/\\(#{delimiters})/) { |escape| escape[1] == '\\' ? escape : escape[1] }
+                end
+                exps << [:static, eval("#{quote_start}#{str}#{quote_end}").to_s]
               when :on_embexpr_beg
                 embedded = shift_balanced_embexpr(tokens)
                 exps << [:dynamic, embedded] unless embedded.empty?
@@ -115,7 +119,7 @@ module Temple
           # Some quotes are split-unsafe. Replace such quotes with null characters.
           def escape_quotes(beg_str, end_str)
             case [beg_str[-1], end_str]
-            when ['(', ')'], ['[', ']'], ['{', '}']
+            when ['(', ')'], ['[', ']'], ['{', '}'], ['<', '>']
               [beg_str.sub(/.\z/) { "\0" }, "\0"]
             else
               [beg_str, end_str]


### PR DESCRIPTION
## Summary
Preserve original paired-delimiter escape semantics when evaluating split static fragments. Include angle brackets among split-unsafe delimiter pairs and keep the original quote metadata for every fragment.

## Reproduction
Using Temple 0.10.7 (master `3994e0374df17cccdc56274b5dfbc865ccf9b733` before the fix):

```ruby
require 'temple'
['%Q<a<#{42}>b>', '%q{a\}b}', '%q(a\)b)'].each do |source|
  exp = Temple::Filters::StringSplitter.new.call([:dynamic, source])
  p eval(Temple::Generators::StringBuffer.new.call(exp))
end
# With TEMPLE_PARSER_ENGINE=ripper: before SyntaxError / extra backslashes;
# after "a<42>b", "a}b", "a)b".
```

## Verification
- Unmodified `rake spec`: 162 examples, zero failures on Ruby 3.2.11 and 4.0.6, each with Prism and Ripper.
- 2,000 focused checks per Ruby/parser combination: seeded Ruby-eval roundtrips for q/Q, all four paired delimiters, escaped backslashes/delimiters, nesting and interpolations.
- All 51 runtime files compile on both Rubies. No test files changed; focused verification ran outside the repository.

## Breaking changes / limitations
No public API change intended. Valid Ruby literals that previously failed or produced extra backslashes now retain their value. Prism remains unchanged. This patch is independent of shorthand-variable handling.
Ruby 2.5–3.1, JRuby and TruffleRuby were not locally exercised; the upstream matrix remains necessary.
