### PR TITLE
Support anonymous and reloaded filter classes

### DIFF
--- a/lib/temple/mixins/dispatcher.rb
+++ b/lib/temple/mixins/dispatcher.rb
@@ -63,7 +63,7 @@ module Temple
         end
         self.class.class_eval <<-RUBY, __FILE__, __LINE__ + 1
           def dispatcher(exp)
-            return replace_dispatcher(exp) if self.class != #{self.class}
+            return replace_dispatcher(exp) if self.class.object_id != #{self.class.object_id}
             #{tree.compile.gsub("\n", "\n  ")}
           end
         RUBY

--- a/lib/temple/mixins/engine_dsl.rb
+++ b/lib/temple/mixins/engine_dsl.rb
@@ -62,7 +62,7 @@ module Temple
       def chain_name(name)
         case name
         when Class
-          name.name.to_sym
+          name.to_s.to_sym
         when Symbol, String
           name.to_sym
         when Regexp
@@ -109,7 +109,7 @@ module Temple
         name = args.shift
         if Class === name
           filter = name
-          name = filter.name.to_sym
+          name = filter.to_s.to_sym
         else
           raise(ArgumentError, 'Name argument must be Class or Symbol') unless Symbol === name
         end

--- a/lib/temple/utils.rb
+++ b/lib/temple/utils.rb
@@ -55,7 +55,7 @@ module Temple
     # @return [String] Variable name
     def unique_name(prefix = nil)
       @unique_name ||= 0
-      prefix ||= (@unique_prefix ||= self.class.name.gsub('::'.freeze, '_'.freeze).downcase)
+      prefix ||= (@unique_prefix ||= (self.class.name || "anonymous_#{self.class.object_id}_").gsub('::'.freeze, '_'.freeze).downcase)
       "_#{prefix}#{@unique_name += 1}"
     end
 


### PR DESCRIPTION
## Summary
Support Class.new filter classes throughout dispatcher generation, default variable naming and Engine DSL registration. Compare generated dispatchers with the original class identity so constant redefinition also cannot trigger recursive recompilation.

## Reproduction
Using Temple 0.10.7 (master `3994e0374df17cccdc56274b5dfbc865ccf9b733` before the fix):

```ruby
require 'temple'
filter = Class.new(Temple::Filter)
p filter.new.call([:static, 'hello']) # Before: SystemStackError
p filter.new.unique_name             # Before: NoMethodError
engine = Class.new(Temple::Engine)
engine.use(filter)                   # Before: NoMethodError
p engine.new.call([:static, 'hello'])
```

## Verification
- Unmodified `rake spec`: 162 examples, zero failures on Ruby 3.2.11 and 4.0.6, each with Prism and Ripper.
- 2,100 focused checks per Ruby/parser combination: anonymous classes, inherited dispatchers, unique valid variables, chain before/after/replace/remove and retained instances after constant redefinition.
- All 51 runtime files compile on both Rubies. No test files changed; focused verification ran outside the repository.

## Breaking changes / limitations
No intended change to named-class chain keys or variable prefixes. Anonymous classes receive distinct generated names. A local Ruby 4.0.6 YJIT comparison (three alternating pairs, five batches each) found no regression: 500,000 dispatches median 0.104914s → 0.092326s, 2,500 Slim compilations 0.845131s → 0.828132s. Allocations were unchanged within measurement noise. These are local microbenchmarks, not application throughput claims.
Ruby 2.5–3.1, JRuby and TruffleRuby were not locally exercised; the upstream matrix remains necessary.
