### PR TITLE
Preserve static literal encodings in generated code

### DIFF
--- a/lib/temple/generator.rb
+++ b/lib/temple/generator.rb
@@ -61,7 +61,7 @@ module Temple
     end
 
     def on_static(text)
-      concat(options[:freeze_static] ? "#{text.inspect}.freeze" : text.inspect)
+      concat(static_expression(text, freeze: options[:freeze_static]))
     end
 
     def on_dynamic(code)
@@ -73,6 +73,15 @@ module Temple
     end
 
     protected
+
+    def static_expression(text, freeze: false)
+      if text.respond_to?(:encoding) && text.encoding != ::Encoding::UTF_8
+        expression = "#{text.b.inspect}.force_encoding(#{text.encoding.name.inspect})"
+      else
+        expression = text.inspect
+      end
+      freeze ? "#{expression}.freeze" : expression
+    end
 
     def buffer
       options[:buffer]

--- a/lib/temple/generators/array_buffer.rb
+++ b/lib/temple/generators/array_buffer.rb
@@ -13,7 +13,7 @@ module Temple
       def call(exp)
         case exp.first
         when :static
-          [save_buffer, "#{buffer} = #{exp.last.inspect}", restore_buffer].compact.join('; ')
+          [save_buffer, "#{buffer} = #{static_expression(exp.last)}", restore_buffer].compact.join('; ')
         when :dynamic
           [save_buffer, "#{buffer} = (#{exp.last}).to_s", restore_buffer].compact.join('; ')
         else


### PR DESCRIPTION
Generate non-UTF-8 static literals from binary bytes plus an explicit force_encoding, including the ArrayBuffer fast path. This preserves source bytes and encoding instead of emitting UTF-8-tagged generated literals.

Verified with the unmodified 162-example suite on Ruby 3.2 and Ruby 4.0 under Prism and Ripper, focused ISO-8859-1 and UTF-16 models, downstream Slim and Slim Rails suites, and package checks.