### PR TITLE
Translate Rails error locations to template source

### DIFF
--- a/lib/temple/templates/rails.rb
+++ b/lib/temple/templates/rails.rb
@@ -17,6 +17,22 @@ module Temple
         self.class.options[:streaming]
       end
 
+      def translate_location(spot, _backtrace_location, source)
+        source_lines = source.lines
+        first_lineno = spot[:first_lineno]
+        return unless first_lineno && first_lineno.between?(1, source_lines.size)
+
+        last_lineno = [spot[:last_lineno] || first_lineno, source_lines.size].min
+        first_line = source_lines[first_lineno - 1]
+        last_line = source_lines[last_lineno - 1]
+        spot.merge(
+          first_column: first_line[/\A[ \t]*/].bytesize,
+          last_lineno: last_lineno,
+          last_column: last_line.chomp.bytesize,
+          script_lines: source_lines
+        )
+      end
+
       def self.register_as(*names)
         raise 'Rails is not loaded - Temple::Templates::Rails cannot be used' unless defined?(::ActionView)
         if ::ActiveSupport::VERSION::MAJOR < 5


### PR DESCRIPTION
Implement the Rails template handler translate_location hook so Action View error highlights reference the original template source rather than generated Ruby. The mapping clamps line bounds and derives columns from the original source lines.

Verified against Rails 8.1 error-highlight calls, direct multiline models, the unmodified Temple suite, and downstream Slim and Slim Rails suites on Ruby 3.2 and Ruby 4.0 with Prism and Ripper.