### PR TITLE
[LOW] Harden test workflow dependencies

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,6 +10,8 @@ on:
       - reopened
   schedule:
     - cron: "00 15 * * *"
+permissions:
+  contents: read
 jobs:
   test:
     runs-on: ubuntu-latest
@@ -29,9 +31,11 @@ jobs:
           - jruby
           - truffleruby-head
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.0
+        with:
+          persist-credentials: false
       - name: Set up Ruby
-        uses: ruby/setup-ruby@v1
+        uses: ruby/setup-ruby@95ef2b042f9d7a56d8268cba8559e2842e2ad01b # v1
         with:
           ruby-version: ${{ matrix.ruby }}
           bundler-cache: true


### PR DESCRIPTION
## Summary

Pin the test workflow's third-party actions to reviewed immutable commits, explicitly restrict the GitHub token to `contents: read`, and stop checkout from persisting credentials that later steps do not need.

## Security impact

The previous `actions/checkout@v7` tag and `ruby/setup-ruby@v1` branch were movable executable dependencies. Compromise or unexpected retargeting of either ref could run changed code with the workflow runner and token context. Severity is **low** because the workflow references no secrets, performs tests only, and fork pull-request tokens are normally restricted; repository-level token defaults were not available from source.

## Verification

- Resolved `actions/checkout@v7` to `3d3c42e5aac5ba805825da76410c181273ba90b1` and `ruby/setup-ruby@v1` to `95ef2b042f9d7a56d8268cba8559e2842e2ad01b`.
- Parsed the workflow with Ruby Psych and asserted every `uses:` selector is a full 40-character commit.
- Asserted `contents: read` and `persist-credentials: false`.
- Ran the unmodified 162-example suite with Prism and Ripper on Ruby 3.2.11 and Ruby 4.0.6: all four runs passed.
- Compiled all 51 runtime Ruby files, built the 0.10.7 gem, and ran `git diff --check`.

No test files changed.

## Breaking changes / limitations

No runtime or package behavior changes. Dependabot or a manual review is still needed when advancing action versions. Hosted checks remain authoritative for the full Ruby/JRuby/TruffleRuby matrix.
